### PR TITLE
chore: Add postsubmit to consume the package to hydra GOPROXY

### DIFF
--- a/.github/workflows/postsubmit.yaml
+++ b/.github/workflows/postsubmit.yaml
@@ -1,0 +1,16 @@
+name: postsubmit
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  presubmit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: hydrate-goproxy
+      run: |
+        mkdir -p hydrate-goproxy
+        cd hydrate-goproxy
+        go mod init hydrate-goproxy
+        go get github.com/awslabs/operatorpkg@HEAD


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Hydrate goproxy on push. Useful for any crawlers of goproxy, until operatorpkg has regular consumers that pull this themselves (e.g. dependabot).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
