### PR TITLE
feat: Accept any instead of client.Object

### DIFF
--- a/object/object.go
+++ b/object/object.go
@@ -39,7 +39,7 @@ func GVK(o client.Object) schema.GroupVersionKind {
 	return lo.Must(apiutil.GVKForObject(o, scheme.Scheme))
 }
 
-func Unmarshal[T client.Object](raw []byte) *T {
+func Unmarshal[T any](raw []byte) *T {
 	t := *new(T)
 	lo.Must0(yaml.Unmarshal(raw, &t))
 	return &t


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Without this change, I'm forced to do crazy things like
```
	CRDs = []**apiextensionsv1.CustomResourceDefinition{
		object.Unmarshal[*apiextensionsv1.CustomResourceDefinition](bytes),
	}
```
because of
```
"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1".CustomResourceDefinition does not satisfy client.Object (method DeepCopyObject has pointer receiver)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
