### PR TITLE
fix: yaml parsing for crds

### DIFF
--- a/object/object.go
+++ b/object/object.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 
 	"github.com/samber/lo"
-	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/yaml"
 )
 
 // GroupVersionKindNamespacedName uniquely identifies an object


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Without this change:
```
  unable to install CRDs onto control plane: unable to create CRD instances: unable to get CRD "" to check if it exists: resource name may not be empty
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
