### PR TITLE
Added context aliasing to simplify consumer imports

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
@@ -13,12 +12,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+type Context = context.Context
+
 func New() context.Context {
 	ctx := controllerruntime.SetupSignalHandler()
 	logger := zapr.NewLogger(lo.Must(zap.NewDevelopment()))
 	klog.SetLogger(logger)
 	log.SetLogger(logger)
-	ctx = Into[logr.Logger](ctx, &logger)
+	ctx = Into(ctx, &logger)
 	return ctx
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Alias context so customers can just import a single context package.


Before

```
import (
        "context"
        operatorcontext "github.com/awslabs/operatorpkg/context"
)
func main() {
	ctx := operatorcontext.New()
	mgr := lo.Must(controllerruntime.NewManager(controllerruntime.GetConfigOrDie(), controllerruntime.Options{
		BaseContext:                   func() context.Context { return ctx },
	}))
}
```

After
```
import (
       "github.com/awslabs/operatorpkg/context"
)
func main() {
	ctx := context.New()
	mgr := lo.Must(controllerruntime.NewManager(controllerruntime.GetConfigOrDie(), controllerruntime.Options{
		BaseContext:                   func() context.Context { return ctx },
	}))
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
