### PR TITLE
feat: Added a modified boolean to condition setters

### DIFF
--- a/status/condition_set_test.go
+++ b/status/condition_set_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Conditions", func() {
 		Expect(conditions.Get(ConditionTypeBar).GetStatus()).To(Equal(metav1.ConditionUnknown))
 		Expect(conditions.Root().GetStatus()).To(Equal(metav1.ConditionUnknown))
 		// Update the condition to true
-		conditions.SetTrue(ConditionTypeFoo)
+		Expect(conditions.SetTrue(ConditionTypeFoo)).To(BeTrue())
 		fooCondition := conditions.Get(ConditionTypeFoo)
 		Expect(fooCondition.Type).To(Equal(ConditionTypeFoo))
 		Expect(fooCondition.Status).To(Equal(metav1.ConditionTrue))
@@ -28,7 +28,7 @@ var _ = Describe("Conditions", func() {
 		Expect(conditions.Root().GetStatus()).To(Equal(metav1.ConditionUnknown))
 		time.Sleep(1 * time.Nanosecond)
 		// Update the other condition to false
-		conditions.SetFalse(ConditionTypeBar, "reason", "message")
+		Expect(conditions.SetFalse(ConditionTypeBar, "reason", "message")).To(BeTrue())
 		fooCondition2 := conditions.Get(ConditionTypeBar)
 		Expect(fooCondition2.Type).To(Equal(ConditionTypeBar))
 		Expect(fooCondition2.Status).To(Equal(metav1.ConditionFalse))
@@ -38,7 +38,7 @@ var _ = Describe("Conditions", func() {
 		Expect(conditions.Root().GetStatus()).To(Equal(metav1.ConditionFalse))
 		time.Sleep(1 * time.Nanosecond)
 		// transition the root condition to true
-		conditions.SetTrueWithReason(ConditionTypeBar, "reason", "message")
+		Expect(conditions.SetTrueWithReason(ConditionTypeBar, "reason", "message")).To(BeTrue())
 		updatedFooCondition := conditions.Get(ConditionTypeBar)
 		Expect(updatedFooCondition.Type).To(Equal(ConditionTypeBar))
 		Expect(updatedFooCondition.Status).To(Equal(metav1.ConditionTrue))
@@ -48,11 +48,14 @@ var _ = Describe("Conditions", func() {
 		Expect(conditions.Root().GetStatus()).To(Equal(metav1.ConditionTrue))
 		time.Sleep(1 * time.Nanosecond)
 		// Transition if the status is the same, but the Reason is different
-		conditions.SetFalse(ConditionTypeBar, "another-reason", "another-message")
+		Expect(conditions.SetFalse(ConditionTypeBar, "another-reason", "another-message")).To(BeTrue())
 		updatedBarCondition := conditions.Get(ConditionTypeBar)
 		Expect(updatedBarCondition.Type).To(Equal(ConditionTypeBar))
 		Expect(updatedBarCondition.Status).To(Equal(metav1.ConditionFalse))
 		Expect(updatedBarCondition.Reason).To(Equal("another-reason"))
 		Expect(updatedBarCondition.LastTransitionTime.UnixNano()).ToNot(BeNumerically("==", fooCondition2.LastTransitionTime.UnixNano()))
+		// Dont transition if reason and message are the same
+		Expect(conditions.SetTrue(ConditionTypeFoo)).To(BeFalse())
+		Expect(conditions.SetFalse(ConditionTypeBar, "another-reason", "another-message")).To(BeFalse())
 	})
 })


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a helper boolean to simplify caller code when modifying status conditions

This was inspired by `modified := controllerutil.SetFinalizer()`

Before
```
	if !obj.StatusConditions().Get(conditionType).IsTrue() {
		obj.StatusConditions().SetTrue(conditionType)
		if err := c.client.Status().Update(ctx, obj); err != nil {
			return reconcile.Result{}, err
		}
	}
```
After
```
	if obj.StatusConditions().SetTrue(conditionType) {
		if err := c.client.Status().Update(ctx, obj); err != nil {
			return reconcile.Result{}, err
		}
	}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
