### PR TITLE
feat: Added a reasonable rate limiter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/prometheus/client_model v0.6.0
 	github.com/samber/lo v1.39.0
 	go.uber.org/zap v1.27.0
+	golang.org/x/time v0.5.0
 	k8s.io/api v0.29.3
 	k8s.io/apimachinery v0.29.3
 	k8s.io/client-go v0.29.3
@@ -60,7 +61,6 @@ require (
 	golang.org/x/sys v0.19.0 // indirect
 	golang.org/x/term v0.19.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
-	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.20.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/reasonable/reasonable.go
+++ b/reasonable/reasonable.go
@@ -1,0 +1,16 @@
+// reasonable contains a set of reasonable defaults that disagree with upstream alternatives
+package reasonable
+
+import (
+	"time"
+
+	"golang.org/x/time/rate"
+	"k8s.io/client-go/util/workqueue"
+)
+
+func RateLimiter() workqueue.RateLimiter {
+	return workqueue.NewMaxOfRateLimiter(
+		workqueue.NewItemExponentialFailureRateLimiter(100*time.Millisecond, 1*time.Minute),
+		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+	)
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The controller runtime's default rate limiter is 1ms -> 1000s, which is a bit unreasonable. I borrowed the reasonable rate limiter's settings used across the Karpenter project, which is better suited for calling cloud APIs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
