### PR TITLE
chore: Made status controller generic and split Apply expectations

### DIFF
--- a/object/object.go
+++ b/object/object.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -37,6 +38,10 @@ func (gvknn GroupVersionKindNamespacedName) String() string {
 
 func GVK(o client.Object) schema.GroupVersionKind {
 	return lo.Must(apiutil.GVKForObject(o, scheme.Scheme))
+}
+
+func New[T any]() T {
+	return reflect.New(reflect.TypeOf(*new(T)).Elem()).Interface().(T)
 }
 
 func Unmarshal[T any](raw []byte) *T {

--- a/status/controller.go
+++ b/status/controller.go
@@ -3,7 +3,6 @@ package status
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"github.com/awslabs/operatorpkg/object"
 	"github.com/prometheus/client_golang/prometheus"
@@ -47,13 +46,13 @@ func NewController[T Object](client client.Client, eventRecorder record.EventRec
 
 func (c *Controller[T]) Register(ctx context.Context, m manager.Manager) error {
 	return controllerruntime.NewControllerManagedBy(m).
-		For(reflect.New(reflect.TypeOf(*new(T)).Elem()).Interface().(T)).
+		For(object.New[T]()).
 		Named("status").
 		Complete(c)
 }
 
 func (c *Controller[T]) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	o := reflect.New(reflect.TypeOf(*new(T)).Elem()).Interface().(T)
+	o := object.New[T]()
 	gvk := object.GVK(o)
 
 	if err := c.kubeClient.Get(ctx, req.NamespacedName, o); err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Use a cleaner generic approach to the status controller
* Broke apart apply and status, since it broke for any async case (e.g. integ test) where the object was modified in flight. I couldn't just use PATCH since CRDs don't support strategic merge patches, so this approach was broken if we ever needed to write values like "" or 0. :(

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
