### PR TITLE
chore: Use reconcile.AsReconciler to call ExpectObjectReconciled

### DIFF
--- a/test/expectations/expectations.go
+++ b/test/expectations/expectations.go
@@ -22,16 +22,16 @@ const (
 	FastPolling = 10 * time.Millisecond
 )
 
-func ExpectObjectReconciled[T client.Object](ctx context.Context, reconciler reconcile.ObjectReconciler[T], object T) reconcile.Result {
+func ExpectObjectReconciled[T client.Object](ctx context.Context, c client.Client, reconciler reconcile.ObjectReconciler[T], object T) reconcile.Result {
 	GinkgoHelper()
-	result, err := reconciler.Reconcile(ctx, object)
+	result, err := reconcile.AsReconciler(c, reconciler).Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(object)})
 	Expect(err).ToNot(HaveOccurred())
 	return result
 }
 
-func ExpectObjectReconcileFailed[T client.Object](ctx context.Context, reconciler reconcile.ObjectReconciler[T], object T) error {
+func ExpectObjectReconcileFailed[T client.Object](ctx context.Context, c client.Client, reconciler reconcile.ObjectReconciler[T], object T) error {
 	GinkgoHelper()
-	_, err := reconciler.Reconcile(ctx, object)
+	_, err := reconcile.AsReconciler(c, reconciler).Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(object)})
 	Expect(err).To(HaveOccurred())
 	return err
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Use `reconcile.AsReconciler` when call `ExpectObjectReconciled` and `ExpectObjectReconcileFailed`. Both of these methods were not actually converting to a reconciler which meant they may not have been reconciling based on the true state of what was on the apiserver. This updates these functions so that they receive a client and get the updated state from the apiserver before reconciling with `reconcile.AsReconciler`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
