### PR TITLE
feat: Mimic the behavior of reconciler.AsReconciler in expectations

### DIFF
--- a/test/expectations/expectations.go
+++ b/test/expectations/expectations.go
@@ -22,15 +22,17 @@ const (
 	FastPolling = 10 * time.Millisecond
 )
 
-func ExpectObjectReconciled[T client.Object](ctx context.Context, reconciler reconcile.ObjectReconciler[T], object T) reconcile.Result {
+func ExpectObjectReconciled[T client.Object](ctx context.Context, client client.Client, reconciler reconcile.ObjectReconciler[T], object T) reconcile.Result {
 	GinkgoHelper()
+	ExpectGet(ctx, client, object)
 	result, err := reconciler.Reconcile(ctx, object)
 	Expect(err).ToNot(HaveOccurred())
 	return result
 }
 
-func ExpectObjectReconcileFailed[T client.Object](ctx context.Context, reconciler reconcile.ObjectReconciler[T], object T) error {
+func ExpectObjectReconcileFailed[T client.Object](ctx context.Context, client client.Client, reconciler reconcile.ObjectReconciler[T], object T) error {
 	GinkgoHelper()
+	ExpectGet(ctx, client, object)
 	_, err := reconciler.Reconcile(ctx, object)
 	Expect(err).To(HaveOccurred())
 	return err


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`reconciler.AsReconciler` automatically performs a GET before calling reconcile. Without this change, the control loop is operating on data in the API server, while test test may be operating on data in memory passed to this function. This can lead to subtle testing bugs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
