### PR TITLE
Add eventually to ExpectStatusConditions

### DIFF
--- a/status/controller_test.go
+++ b/status/controller_test.go
@@ -56,8 +56,8 @@ var _ = Describe("Controller", func() {
 		time.Sleep(time.Second * 1)
 		testObject.StatusConditions().SetTrue(ConditionTypeFoo)
 		ExpectApplied(ctx, client, testObject)
-		EventuallyExpectStatusConditions(ctx, client, testObject, FastTimeout, status.Condition{Type: ConditionTypeFoo, Status: metav1.ConditionTrue})
 		ExpectReconciled(ctx, controller, testObject)
+		ExpectStatusConditions(ctx, client, FastTimeout, testObject, status.Condition{Type: ConditionTypeFoo, Status: metav1.ConditionTrue})
 
 		Expect(GetMetric("operator_status_condition_count", conditionLabels(status.ConditionReady, metav1.ConditionTrue))).To(BeNil())
 		Expect(GetMetric("operator_status_condition_count", conditionLabels(status.ConditionReady, metav1.ConditionFalse))).To(BeNil())
@@ -84,8 +84,8 @@ var _ = Describe("Controller", func() {
 		// Transition Bar, root condition should also flip
 		testObject.StatusConditions().SetTrueWithReason(ConditionTypeBar, "reason", "message")
 		ExpectApplied(ctx, client, testObject)
-		EventuallyExpectStatusConditions(ctx, client, testObject, FastTimeout, status.Condition{Type: ConditionTypeBar, Status: metav1.ConditionTrue, Reason: "reason", Message: "message"})
 		ExpectReconciled(ctx, controller, testObject)
+		ExpectStatusConditions(ctx, client, FastTimeout, testObject, status.Condition{Type: ConditionTypeBar, Status: metav1.ConditionTrue, Reason: "reason", Message: "message"})
 
 		Expect(GetMetric("operator_status_condition_count", conditionLabels(status.ConditionReady, metav1.ConditionTrue)).GetGauge().GetValue()).To(BeEquivalentTo(1))
 		Expect(GetMetric("operator_status_condition_count", conditionLabels(status.ConditionReady, metav1.ConditionFalse))).To(BeNil())

--- a/status/controller_test.go
+++ b/status/controller_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Controller", func() {
 		time.Sleep(time.Second * 1)
 		testObject.StatusConditions().SetTrue(ConditionTypeFoo)
 		ExpectApplied(ctx, client, testObject)
-		ExpectStatusConditions(ctx, client, testObject, status.Condition{Type: ConditionTypeFoo, Status: metav1.ConditionTrue})
+		EventuallyExpectStatusConditions(ctx, client, testObject, FastTimeout, status.Condition{Type: ConditionTypeFoo, Status: metav1.ConditionTrue})
 		ExpectReconciled(ctx, controller, testObject)
 
 		Expect(GetMetric("operator_status_condition_count", conditionLabels(status.ConditionReady, metav1.ConditionTrue))).To(BeNil())
@@ -84,7 +84,7 @@ var _ = Describe("Controller", func() {
 		// Transition Bar, root condition should also flip
 		testObject.StatusConditions().SetTrueWithReason(ConditionTypeBar, "reason", "message")
 		ExpectApplied(ctx, client, testObject)
-		ExpectStatusConditions(ctx, client, testObject, status.Condition{Type: ConditionTypeBar, Status: metav1.ConditionTrue, Reason: "reason", Message: "message"})
+		EventuallyExpectStatusConditions(ctx, client, testObject, FastTimeout, status.Condition{Type: ConditionTypeBar, Status: metav1.ConditionTrue, Reason: "reason", Message: "message"})
 		ExpectReconciled(ctx, controller, testObject)
 
 		Expect(GetMetric("operator_status_condition_count", conditionLabels(status.ConditionReady, metav1.ConditionTrue)).GetGauge().GetValue()).To(BeEquivalentTo(1))

--- a/status/controller_test.go
+++ b/status/controller_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Controller", func() {
 		time.Sleep(time.Second * 1)
 		testObject.StatusConditions().SetTrue(ConditionTypeFoo)
 		ExpectApplied(ctx, client, testObject)
-		ExpectStatusConditions(testObject, status.Condition{Type: ConditionTypeFoo, Status: metav1.ConditionTrue})
+		ExpectStatusConditions(ctx, client, testObject, status.Condition{Type: ConditionTypeFoo, Status: metav1.ConditionTrue})
 		ExpectReconciled(ctx, controller, testObject)
 
 		Expect(GetMetric("operator_status_condition_count", conditionLabels(status.ConditionReady, metav1.ConditionTrue))).To(BeNil())
@@ -84,7 +84,7 @@ var _ = Describe("Controller", func() {
 		// Transition Bar, root condition should also flip
 		testObject.StatusConditions().SetTrueWithReason(ConditionTypeBar, "reason", "message")
 		ExpectApplied(ctx, client, testObject)
-		ExpectStatusConditions(testObject, status.Condition{Type: ConditionTypeBar, Status: metav1.ConditionTrue, Reason: "reason", Message: "message"})
+		ExpectStatusConditions(ctx, client, testObject, status.Condition{Type: ConditionTypeBar, Status: metav1.ConditionTrue, Reason: "reason", Message: "message"})
 		ExpectReconciled(ctx, controller, testObject)
 
 		Expect(GetMetric("operator_status_condition_count", conditionLabels(status.ConditionReady, metav1.ConditionTrue)).GetGauge().GetValue()).To(BeEquivalentTo(1))

--- a/test/expectations/expectations.go
+++ b/test/expectations/expectations.go
@@ -94,13 +94,13 @@ func ExpectStatusConditions(ctx context.Context, c client.Client, obj status.Obj
 				return fmt.Errorf("condition %s does not exist", cond.Type)
 			}
 			if cond.Status != "" && objCondition.Status != cond.Status {
-				return fmt.Errorf("status mismatch (got %s, expected %s)", objCondition.Status, cond.Status)
+				return fmt.Errorf("condition %s, status mismatch (got %s, expected %s)", objCondition.Type, objCondition.Status, cond.Status)
 			}
 			if cond.Message != "" && objCondition.Message != cond.Message {
-				return fmt.Errorf("message mismatch (got %s, expected %s)", objCondition.Message, cond.Message)
+				return fmt.Errorf("condition %s, message mismatch (got %s, expected %s)", objCondition.Type, objCondition.Message, cond.Message)
 			}
 			if cond.Reason != "" && objCondition.Reason != cond.Reason {
-				return fmt.Errorf("reason mismatch (Got %s, expected %s)", objCondition.Reason, cond.Reason)
+				return fmt.Errorf("condition %s, reason mismatch (got %s, expected %s)", objCondition.Type, objCondition.Reason, cond.Reason)
 			}
 		}
 		return nil

--- a/test/expectations/expectations.go
+++ b/test/expectations/expectations.go
@@ -81,7 +81,7 @@ func ExpectApplied(ctx context.Context, c client.Client, objects ...client.Objec
 	}
 }
 
-func EventuallyExpectStatusConditions(ctx context.Context, c client.Client, obj status.Object, timeout time.Duration, conditions ...status.Condition) {
+func ExpectStatusConditions(ctx context.Context, c client.Client, timeout time.Duration, obj status.Object, conditions ...status.Condition) {
 	Eventually(func(g Gomega) {
 		g.Expect(c.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(BeNil())
 		objStatus := obj.StatusConditions()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds an eventually function to ExpectStatusConditions. This will fill the object with a Get call, and only succeed if the status condition is eventually what we expect. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
