### PR TITLE
feat: Add client-go metrics registration to operatorpkg

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,129 @@
+package metrics
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/samber/lo"
+	clientmetrics "k8s.io/client-go/tools/metrics"
+)
+
+// This package adds client-go metrics that can be surfaced through the Prometheus metrics server
+// This is based on the reference implementation that was pulled out in controller-runtime in https://github.com/kubernetes-sigs/controller-runtime/pull/2298
+
+var (
+	requestResult = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "client_go_request_total",
+			Help: "Number of HTTP requests, partitioned by status code and method.",
+		},
+		[]string{"code", "method"},
+	)
+	requestLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "client_go_request_duration_seconds",
+		Help:    "Request latency in seconds. Broken down by verb, group, version, kind, and subresource.",
+		Buckets: prometheus.ExponentialBuckets(0.001, 2, 10),
+	}, []string{"verb", "group", "version", "kind", "subresource"})
+)
+
+// RegisterClientMetrics sets up the client latency and result metrics from client-go.
+func RegisterClientMetrics(r prometheus.Registerer) {
+	// register the metrics with our registry
+	r.MustRegister(requestResult, requestLatency)
+
+	clientmetrics.RequestLatency = &latencyAdapter{metric: requestLatency}
+	clientmetrics.RequestResult = &resultAdapter{metric: requestResult}
+}
+
+type resultAdapter struct {
+	metric *prometheus.CounterVec
+}
+
+func (r *resultAdapter) Increment(_ context.Context, code, method, _ string) {
+	r.metric.WithLabelValues(code, method).Inc()
+}
+
+// latencyAdapter implements LatencyMetric.
+type latencyAdapter struct {
+	metric *prometheus.HistogramVec
+}
+
+// Observe increments the request latency metric for the given verb/group/version/kind/subresource.
+func (l *latencyAdapter) Observe(_ context.Context, verb string, u url.URL, latency time.Duration) {
+	if data := parsePath(u.Path); data != nil {
+		// We update the "verb" to better reflect the action being taken by client-go
+		switch verb {
+		case "POST":
+			verb = "CREATE"
+		case "GET":
+			if !strings.Contains(u.Path, "{name}") {
+				verb = "LIST"
+			}
+		case "PUT":
+			if !strings.Contains(u.Path, "{name}") {
+				verb = "CREATE"
+			} else {
+				verb = "UPDATE"
+			}
+		}
+		l.metric.With(prometheus.Labels{
+			"verb":        verb,
+			"group":       data.group,
+			"version":     data.version,
+			"kind":        data.kind,
+			"subresource": data.subresource,
+		}).Observe(latency.Seconds())
+	}
+}
+
+// pathData stores data parsed out from the URL path
+type pathData struct {
+	group       string
+	version     string
+	kind        string
+	subresource string
+}
+
+// parsePath parses out the URL called from client-go to return back the group, version, kind, and subresource
+// urls are formatted similar to /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name} or /apis/karpenter.sh/v1beta1/nodeclaims/{name}
+func parsePath(path string) *pathData {
+	parts := strings.Split(path, "/")[1:]
+
+	var groupIdx, versionIdx, kindIdx int
+	switch parts[0] {
+	case "api":
+		groupIdx = 0
+	case "apis":
+		groupIdx = 1
+	default:
+		return nil
+	}
+	// If the url is too short, then it's not interesting to us
+	if len(parts) < groupIdx+3 {
+		return nil
+	}
+	// This resource is namespaced
+	if parts[groupIdx+2] == "namespaces" {
+		versionIdx = groupIdx + 1
+		kindIdx = versionIdx + 3
+	} else {
+		versionIdx = groupIdx + 1
+		kindIdx = versionIdx + 1
+	}
+
+	// If we have a subresource, it's going to be two indices after the kind
+	var subresource string
+	if len(parts) == kindIdx+3 {
+		subresource = parts[kindIdx+2]
+	}
+	return &pathData{
+		// If the group index is 0, this is part of the core API, so there's no group
+		group:       lo.Ternary(groupIdx == 0, "", parts[groupIdx]),
+		version:     parts[versionIdx],
+		kind:        parts[kindIdx],
+		subresource: subresource,
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add the ability to register client metrics with the `RegisterClientMetrics()` call.

When calling the metrics endpoint, we see the following output reflecting the updated metrics that are returned here -- which reflects the actual apiserver calls that are made (not hitting the controller-runtime cache)

```
client_go_request_duration_seconds_count{group="",kind="events",subresource="",verb="PATCH",version="v1"} 10
client_go_request_duration_seconds_count{group="",kind="nodes",subresource="",verb="DELETE",version="v1"} 12
client_go_request_duration_seconds_count{group="",kind="nodes",subresource="",verb="LIST",version="v1"} 1
client_go_request_duration_seconds_count{group="",kind="nodes",subresource="",verb="PATCH",version="v1"} 12
client_go_request_duration_seconds_count{group="",kind="pods",subresource="",verb="LIST",version="v1"} 1
client_go_request_duration_seconds_count{group="",kind="pods",subresource="eviction",verb="CREATE",version="v1"} 29
client_go_request_duration_seconds_count{group="",kind="services",subresource="",verb="GET",version="v1"} 1
client_go_request_duration_seconds_count{group="apps",kind="daemonsets",subresource="",verb="LIST",version="v1"} 1
client_go_request_duration_seconds_count{group="coordination.k8s.io",kind="leases",subresource="",verb="GET",version="v1"} 3
client_go_request_duration_seconds_count{group="coordination.k8s.io",kind="leases",subresource="",verb="LIST",version="v1"} 1
client_go_request_duration_seconds_count{group="coordination.k8s.io",kind="leases",subresource="",verb="UPDATE",version="v1"} 78
client_go_request_duration_seconds_count{group="karpenter.k8s.aws",kind="ec2nodeclasses",subresource="",verb="LIST",version="v1beta1"} 2
client_go_request_duration_seconds_count{group="karpenter.sh",kind="nodeclaims",subresource="",verb="CREATE",version="v1beta1"} 12
client_go_request_duration_seconds_count{group="karpenter.sh",kind="nodeclaims",subresource="",verb="LIST",version="v1beta1"} 1
client_go_request_duration_seconds_count{group="karpenter.sh",kind="nodeclaims",subresource="",verb="PATCH",version="v1beta1"} 24
client_go_request_duration_seconds_count{group="karpenter.sh",kind="nodeclaims",subresource="status",verb="PATCH",version="v1beta1"} 12
client_go_request_duration_seconds_count{group="karpenter.sh",kind="nodeclaims",subresource="status",verb="UPDATE",version="v1beta1"} 40
client_go_request_duration_seconds_count{group="karpenter.sh",kind="nodepools",subresource="",verb="LIST",version="v1beta1"} 1
client_go_request_duration_seconds_count{group="karpenter.sh",kind="nodepools",subresource="status",verb="PATCH",version="v1beta1"} 14
client_go_request_duration_seconds_count{group="policy",kind="poddisruptionbudgets",subresource="",verb="LIST",version="v1"} 1
client_go_request_duration_seconds_count{group="storage.k8s.io",kind="csinodes",subresource="",verb="LIST",version="v1"} 1
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
