### PR TITLE
fix: support namespaces requests for client-go metrics

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -105,8 +105,8 @@ func parsePath(path string) *pathData {
 	if len(parts) < groupIdx+3 {
 		return nil
 	}
-	// This resource is namespaced
-	if parts[groupIdx+2] == "namespaces" {
+	// This resource is namespaced and the resource is not the namespace
+	if parts[groupIdx+2] == "namespaces" && len(parts) > groupIdx+4 {
 		versionIdx = groupIdx + 1
 		kindIdx = versionIdx + 3
 	} else {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Don't panic for the following requests for client-go metrics:
- `/api/v1/namespaces`
- `/api/v1/namespaces/{name}`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
