### PR TITLE
chore: Update latency metric buckets

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -25,7 +25,7 @@ var (
 	requestLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "client_go_request_duration_seconds",
 		Help:    "Request latency in seconds. Broken down by verb, group, version, kind, and subresource.",
-		Buckets: prometheus.ExponentialBuckets(0.001, 2, 10),
+		Buckets: prometheus.ExponentialBuckets(0.001, 1.5, 20),
 	}, []string{"verb", "group", "version", "kind", "subresource"})
 )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updates latency metric buckets to be more granular for `client_go_request_duration` to be more granular and cover a broader time range

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
