### PR TITLE
chore: Bump operatorpkg to use go 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/awslabs/operatorpkg
 
-go 1.22.2
+go 1.23.0
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Use `1.23` toolchain and compiler

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
