### PR TITLE
Apply unique controller name to each registration of status controller

### DIFF
--- a/status/controller.go
+++ b/status/controller.go
@@ -3,6 +3,8 @@ package status
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -52,7 +54,7 @@ func (c *Controller[T]) Register(_ context.Context, m manager.Manager) error {
 	return controllerruntime.NewControllerManagedBy(m).
 		For(object.New[T]()).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
-		Named("status").
+		Named(fmt.Sprintf("operatorpkg.%s.status", strings.ToLower(reflect.TypeOf(object.New[T]()).Elem().Name()))).
 		Complete(c)
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

https://github.com/kubernetes-sigs/controller-runtime/pull/2902 breaks some downstream integrations that use the status controller if the status controller is registered multiple times

### Before Change

```
panic: controller with name status already exists. Controller names must be unique to avoid multiple controllers reporting to the same metric

goroutine 1 [running]:
github.com/samber/lo.must({0x10532eec0, 0x1400089f4a0}, {0x0, 0x0, 0x0})
        /Users/joinnis/go/pkg/mod/github.com/samber/lo@v1.47.0/errors.go:53 +0x1cc
github.com/samber/lo.Must0(...)
        /Users/joinnis/go/pkg/mod/github.com/samber/lo@v1.47.0/errors.go:72
sigs.k8s.io/karpenter/pkg/operator.(*Operator).WithControllers(0x140008a3080, {0x1058d5640, 0x1400081b4a0}, {0x14000eaaa80?, 0x1058e82e0?, 0x140005fe7e0?})
        /Users/joinnis/github/karpenter/pkg/operator/operator.go:214 +0x48
main.main()
        /Users/joinnis/github/karpenter-provider-aws/cmd/controller/main.go:44 +0x2cc

```

### After Change

```
{"level":"INFO","time":"2024-09-12T11:28:25.364-0700","message":"Unable to read vcs.revision from binary"}
{"level":"INFO","time":"2024-09-12T11:28:27.147-0700","logger":"controller","message":"starting server","name":"health probe","addr":"[::]:8081"}
{"level":"INFO","time":"2024-09-12T11:28:27.147-0700","logger":"controller.controller-runtime.metrics","message":"Starting metrics server"}
{"level":"INFO","time":"2024-09-12T11:28:27.147-0700","logger":"controller.controller-runtime.metrics","message":"Serving metrics server","bindAddress":":8080","secure":false}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"eviction-queue","source":"channel source: 0x140005f1f10"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"state.nodeclaim","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1.NodeClaim"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"nodeclaim.expiration","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1.NodeClaim"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"state.daemonset","controllerGroup":"apps","controllerKind":"DaemonSet","source":"kind source: *v1.DaemonSet"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"provisioner.trigger.pod","controllerGroup":"","controllerKind":"Pod","source":"kind source: *v1.Pod"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"metrics.nodepool","controllerGroup":"karpenter.sh","controllerKind":"NodePool","source":"kind source: *v1.NodePool"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"metrics.node","source":"channel source: 0x140004ac310"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting Controller","controller":"metrics.node"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting Controller","controller":"eviction-queue"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting workers","controller":"eviction-queue","worker count":1}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting workers","controller":"metrics.node","worker count":1}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting Controller","controller":"provisioner.trigger.pod","controllerGroup":"","controllerKind":"Pod"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting Controller","controller":"nodeclaim.expiration","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting workers","controller":"nodeclaim.expiration","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","worker count":1}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting Controller","controller":"state.daemonset","controllerGroup":"apps","controllerKind":"DaemonSet"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"nodeclaim.podevents","controllerGroup":"","controllerKind":"Pod","source":"kind source: *v1.Pod"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting Controller","controller":"nodeclaim.podevents","controllerGroup":"","controllerKind":"Pod"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"provisioner","source":"channel source: 0x140005f1e30"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting Controller","controller":"provisioner"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting workers","controller":"provisioner","worker count":1}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"metrics.pod","controllerGroup":"","controllerKind":"Pod","source":"kind source: *v1.Pod"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting Controller","controller":"metrics.nodepool","controllerGroup":"karpenter.sh","controllerKind":"NodePool"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"nodepool.readiness","controllerGroup":"karpenter.sh","controllerKind":"NodePool","source":"kind source: *v1.NodePool"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting Controller","controller":"state.nodeclaim","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"nodepool.readiness","controllerGroup":"karpenter.sh","controllerKind":"NodePool","source":"kind source: *v1.EC2NodeClass"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"nodeclaim.disruption","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1.NodeClaim"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"nodeclaim.disruption","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1.EC2NodeClass"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"nodeclaim.disruption","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1.NodePool"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting Controller","controller":"nodepool.readiness","controllerGroup":"karpenter.sh","controllerKind":"NodePool"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"nodeclaim.consistency","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1.NodeClaim"}
{"level":"INFO","time":"2024-09-12T11:28:27.250-0700","logger":"controller","message":"Starting EventSource","controller":"nodeclaim.consistency","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1.Node"}
{"level":"INFO","time":"2024-09-12T11:28:27.250-0700","logger":"controller","message":"Starting Controller","controller":"nodeclaim.consistency","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"nodeclass.termination","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","source":"kind source: *v1.EC2NodeClass"}
{"level":"INFO","time":"2024-09-12T11:28:27.250-0700","logger":"controller","message":"Starting EventSource","controller":"nodeclass.termination","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","source":"kind source: *v1.NodeClaim"}
{"level":"INFO","time":"2024-09-12T11:28:27.250-0700","logger":"controller","message":"Starting Controller","controller":"nodeclass.termination","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"providers.instancetype","source":"channel source: 0x140004ac690"}
{"level":"INFO","time":"2024-09-12T11:28:27.250-0700","logger":"controller","message":"Starting Controller","controller":"providers.instancetype"}
{"level":"INFO","time":"2024-09-12T11:28:27.250-0700","logger":"controller","message":"Starting workers","controller":"providers.instancetype","worker count":1}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"instance.garbagecollection","source":"channel source: 0x140004ac4d0"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"nodeclass.status","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","source":"kind source: *v1.EC2NodeClass"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"nodepool.hash","controllerGroup":"karpenter.sh","controllerKind":"NodePool","source":"kind source: *v1.NodePool"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"disruption","source":"channel source: 0x140004ac1c0"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"state.pod","controllerGroup":"","controllerKind":"Pod","source":"kind source: *v1.Pod"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"state.node","controllerGroup":"","controllerKind":"Node","source":"kind source: *v1.Node"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"state.nodepool","controllerGroup":"karpenter.sh","controllerKind":"NodePool","source":"kind source: *v1.NodePool"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"provisioner.trigger.node","controllerGroup":"","controllerKind":"Node","source":"kind source: *v1.Node"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"disruption.queue","source":"channel source: 0x140004ac070"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"node.termination","controllerGroup":"","controllerKind":"Node","source":"kind source: *v1.Node"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting Controller","controller":"metrics.pod","controllerGroup":"","controllerKind":"Pod"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1.NodeClaim"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"operatorpkg.nodeclaim.status","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1.NodeClaim"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"nodepool.validation","controllerGroup":"karpenter.sh","controllerKind":"NodePool","source":"kind source: *v1.NodePool"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"nodeclaim.termination","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1.NodeClaim"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"nodeclaim.garbagecollection","source":"channel source: 0x140004ac3f0"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"nodeclass.hash","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","source":"kind source: *v1.EC2NodeClass"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"operatorpkg.nodepool.status","controllerGroup":"karpenter.sh","controllerKind":"NodePool","source":"kind source: *v1.NodePool"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"nodepool.counter","controllerGroup":"karpenter.sh","controllerKind":"NodePool","source":"kind source: *v1.NodePool"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"nodeclaim.tagging","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1.NodeClaim"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"providers.pricing","source":"channel source: 0x140004ac5b0"}
{"level":"INFO","time":"2024-09-12T11:28:27.249-0700","logger":"controller","message":"Starting EventSource","controller":"operatorpkg.ec2nodeclass.status","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","source":"kind source: *v1.EC2NodeClass"}
{"level":"INFO","time":"2024-09-12T11:28:27.250-0700","logger":"controller","message":"Starting EventSource","controller":"nodeclaim.disruption","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1.Pod"}
{"level":"INFO","time":"2024-09-12T11:28:27.250-0700","logger":"controller","message":"Starting Controller","controller":"instance.garbagecollection"}
{"level":"INFO","time":"2024-09-12T11:28:27.250-0700","logger":"controller","message":"Starting Controller","controller":"nodepool.hash","controllerGroup":"karpenter.sh","controllerKind":"NodePool"}
{"level":"INFO","time":"2024-09-12T11:28:27.250-0700","logger":"controller","message":"Starting Controller","controller":"nodeclass.status","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass"}
{"level":"INFO","time":"2024-09-12T11:28:27.250-0700","logger":"controller","message":"Starting Controller","controller":"state.pod","controllerGroup":"","controllerKind":"Pod"}
{"level":"INFO","time":"2024-09-12T11:28:27.250-0700","logger":"controller","message":"Starting Controller","controller":"state.node","controllerGroup":"","controllerKind":"Node"}
{"level":"INFO","time":"2024-09-12T11:28:27.250-0700","logger":"controller","message":"Starting Controller","controller":"disruption"}
{"level":"INFO","time":"2024-09-12T11:28:27.251-0700","logger":"controller","message":"Starting workers","controller":"disruption","worker count":1}
{"level":"INFO","time":"2024-09-12T11:28:27.251-0700","logger":"controller","message":"Starting Controller","controller":"state.nodepool","controllerGroup":"karpenter.sh","controllerKind":"NodePool"}
{"level":"INFO","time":"2024-09-12T11:28:27.251-0700","logger":"controller","message":"Starting Controller","controller":"disruption.queue"}
{"level":"INFO","time":"2024-09-12T11:28:27.251-0700","logger":"controller","message":"Starting workers","controller":"disruption.queue","worker count":1}
{"level":"INFO","time":"2024-09-12T11:28:27.251-0700","logger":"controller","message":"Starting Controller","controller":"provisioner.trigger.node","controllerGroup":"","controllerKind":"Node"}
{"level":"INFO","time":"2024-09-12T11:28:27.251-0700","logger":"controller","message":"Starting Controller","controller":"node.termination","controllerGroup":"","controllerKind":"Node"}
{"level":"INFO","time":"2024-09-12T11:28:27.251-0700","logger":"controller","message":"Starting Controller","controller":"operatorpkg.nodeclaim.status","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim"}
{"level":"INFO","time":"2024-09-12T11:28:27.251-0700","logger":"controller","message":"Starting EventSource","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1.Node"}
{"level":"INFO","time":"2024-09-12T11:28:27.252-0700","logger":"controller","message":"Starting Controller","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim"}
{"level":"INFO","time":"2024-09-12T11:28:27.251-0700","logger":"controller","message":"Starting EventSource","controller":"nodeclaim.termination","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","source":"kind source: *v1.Node"}
{"level":"INFO","time":"2024-09-12T11:28:27.252-0700","logger":"controller","message":"Starting Controller","controller":"nodeclaim.termination","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim"}
{"level":"INFO","time":"2024-09-12T11:28:27.251-0700","logger":"controller","message":"Starting Controller","controller":"nodepool.validation","controllerGroup":"karpenter.sh","controllerKind":"NodePool"}
{"level":"INFO","time":"2024-09-12T11:28:27.251-0700","logger":"controller","message":"Starting Controller","controller":"nodeclass.hash","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass"}
{"level":"INFO","time":"2024-09-12T11:28:27.251-0700","logger":"controller","message":"Starting Controller","controller":"nodeclaim.garbagecollection"}
{"level":"INFO","time":"2024-09-12T11:28:27.252-0700","logger":"controller","message":"Starting workers","controller":"nodeclaim.garbagecollection","worker count":1}
{"level":"INFO","time":"2024-09-12T11:28:27.251-0700","logger":"controller","message":"Starting EventSource","controller":"nodepool.counter","controllerGroup":"karpenter.sh","controllerKind":"NodePool","source":"kind source: *v1.NodeClaim"}
{"level":"INFO","time":"2024-09-12T11:28:27.252-0700","logger":"controller","message":"Starting EventSource","controller":"nodepool.counter","controllerGroup":"karpenter.sh","controllerKind":"NodePool","source":"kind source: *v1.Node"}
{"level":"INFO","time":"2024-09-12T11:28:27.252-0700","logger":"controller","message":"Starting Controller","controller":"nodepool.counter","controllerGroup":"karpenter.sh","controllerKind":"NodePool"}
{"level":"INFO","time":"2024-09-12T11:28:27.251-0700","logger":"controller","message":"Starting Controller","controller":"operatorpkg.nodepool.status","controllerGroup":"karpenter.sh","controllerKind":"NodePool"}
{"level":"INFO","time":"2024-09-12T11:28:27.251-0700","logger":"controller","message":"Starting Controller","controller":"operatorpkg.ec2nodeclass.status","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass"}
{"level":"INFO","time":"2024-09-12T11:28:27.251-0700","logger":"controller","message":"Starting Controller","controller":"providers.pricing"}
{"level":"INFO","time":"2024-09-12T11:28:27.252-0700","logger":"controller","message":"Starting workers","controller":"providers.pricing","worker count":1}
{"level":"INFO","time":"2024-09-12T11:28:27.251-0700","logger":"controller","message":"Starting Controller","controller":"nodeclaim.tagging","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim"}
{"level":"INFO","time":"2024-09-12T11:28:27.251-0700","logger":"controller","message":"Starting Controller","controller":"nodeclaim.disruption","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim"}
{"level":"INFO","time":"2024-09-12T11:28:27.251-0700","logger":"controller","message":"Starting workers","controller":"instance.garbagecollection","worker count":1}
{"level":"INFO","time":"2024-09-12T11:28:27.409-0700","logger":"controller","message":"Starting workers","controller":"state.daemonset","controllerGroup":"apps","controllerKind":"DaemonSet","worker count":10}
{"level":"INFO","time":"2024-09-12T11:28:27.409-0700","logger":"controller","message":"Starting workers","controller":"metrics.nodepool","controllerGroup":"karpenter.sh","controllerKind":"NodePool","worker count":1}
{"level":"INFO","time":"2024-09-12T11:28:27.409-0700","logger":"controller","message":"Starting workers","controller":"node.termination","controllerGroup":"","controllerKind":"Node","worker count":100}
{"level":"INFO","time":"2024-09-12T11:28:27.409-0700","logger":"controller","message":"Starting workers","controller":"provisioner.trigger.pod","controllerGroup":"","controllerKind":"Pod","worker count":10}
{"level":"INFO","time":"2024-09-12T11:28:27.409-0700","logger":"controller","message":"Starting workers","controller":"metrics.pod","controllerGroup":"","controllerKind":"Pod","worker count":1}
{"level":"INFO","time":"2024-09-12T11:28:27.409-0700","logger":"controller","message":"Starting workers","controller":"nodeclaim.podevents","controllerGroup":"","controllerKind":"Pod","worker count":1}
{"level":"INFO","time":"2024-09-12T11:28:27.409-0700","logger":"controller","message":"Starting workers","controller":"state.nodeclaim","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","worker count":10}
{"level":"INFO","time":"2024-09-12T11:28:27.409-0700","logger":"controller","message":"Starting workers","controller":"nodeclaim.tagging","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","worker count":1}
{"level":"INFO","time":"2024-09-12T11:28:27.409-0700","logger":"controller","message":"Starting workers","controller":"operatorpkg.nodeclaim.status","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","worker count":10}
{"level":"INFO","time":"2024-09-12T11:28:27.443-0700","logger":"controller","message":"Starting workers","controller":"nodepool.readiness","controllerGroup":"karpenter.sh","controllerKind":"NodePool","worker count":10}
{"level":"INFO","time":"2024-09-12T11:28:27.443-0700","logger":"controller","message":"Starting workers","controller":"nodeclass.status","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","worker count":10}
{"level":"INFO","time":"2024-09-12T11:28:27.443-0700","logger":"controller","message":"Starting workers","controller":"nodeclass.termination","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","worker count":10}
{"level":"INFO","time":"2024-09-12T11:28:27.443-0700","logger":"controller","message":"Starting workers","controller":"provisioner.trigger.node","controllerGroup":"","controllerKind":"Node","worker count":10}
{"level":"INFO","time":"2024-09-12T11:28:27.443-0700","logger":"controller","message":"Starting workers","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","worker count":1000}
{"level":"INFO","time":"2024-09-12T11:28:27.443-0700","logger":"controller","message":"Starting workers","controller":"nodeclaim.consistency","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","worker count":10}
{"level":"INFO","time":"2024-09-12T11:28:27.443-0700","logger":"controller","message":"Starting workers","controller":"state.node","controllerGroup":"","controllerKind":"Node","worker count":10}
{"level":"INFO","time":"2024-09-12T11:28:27.443-0700","logger":"controller","message":"Starting workers","controller":"state.nodepool","controllerGroup":"karpenter.sh","controllerKind":"NodePool","worker count":10}
{"level":"INFO","time":"2024-09-12T11:28:27.443-0700","logger":"controller","message":"Starting workers","controller":"nodepool.hash","controllerGroup":"karpenter.sh","controllerKind":"NodePool","worker count":10}
{"level":"INFO","time":"2024-09-12T11:28:27.443-0700","logger":"controller","message":"Starting workers","controller":"nodeclass.hash","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","worker count":10}
{"level":"INFO","time":"2024-09-12T11:28:27.443-0700","logger":"controller","message":"Starting workers","controller":"nodeclaim.termination","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","worker count":100}
{"level":"INFO","time":"2024-09-12T11:28:27.443-0700","logger":"controller","message":"Starting workers","controller":"state.pod","controllerGroup":"","controllerKind":"Pod","worker count":10}
{"level":"INFO","time":"2024-09-12T11:28:27.443-0700","logger":"controller","message":"Starting workers","controller":"nodepool.validation","controllerGroup":"karpenter.sh","controllerKind":"NodePool","worker count":10}
{"level":"INFO","time":"2024-09-12T11:28:27.443-0700","logger":"controller","message":"Starting workers","controller":"nodeclaim.disruption","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","worker count":10}
{"level":"INFO","time":"2024-09-12T11:28:27.443-0700","logger":"controller","message":"Starting workers","controller":"operatorpkg.nodepool.status","controllerGroup":"karpenter.sh","controllerKind":"NodePool","worker count":10}
{"level":"INFO","time":"2024-09-12T11:28:27.444-0700","logger":"controller","message":"Starting workers","controller":"operatorpkg.ec2nodeclass.status","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","worker count":10}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
