### PR TITLE
feat: Add interface functions for prometheus metrics to extend to other metric types

### DIFF
--- a/metrics/emf.go
+++ b/metrics/emf.go
@@ -1,0 +1,189 @@
+package metrics
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+
+	"github.com/samber/lo"
+)
+
+type EMF struct {
+	writer               io.Writer
+	namespace            string
+	name                 string
+	dimensions           [][]string
+	additionalProperties []map[string]string
+}
+
+func NewEMF(writer io.Writer, namespace, name string, dimensions [][]string, additionalProperties ...map[string]string) *EMF {
+	return &EMF{writer: writer, namespace: namespace, name: name, dimensions: dimensions, additionalProperties: additionalProperties}
+}
+
+func (e *EMF) withDimensions(entry Entry, dimensions ...[]string) Entry {
+	entry.AddDimensions(dimensions...)
+	return entry
+}
+
+func (e *EMF) withProperties(entry Entry, labels map[string]string) Entry {
+	for k, v := range labels {
+		entry.AddProperty(k, v)
+	}
+	for _, m := range e.additionalProperties {
+		for k, v := range m {
+			entry.AddProperty(k, v)
+		}
+	}
+	return entry
+}
+
+type EMFCounter struct {
+	*EMF
+}
+
+func NewEMFCounter(writer io.Writer, namespace, name string, dimensions [][]string, additionalProperties ...map[string]string) CounterMetric {
+	return &EMFCounter{EMF: NewEMF(writer, namespace, name, dimensions, additionalProperties...)}
+}
+
+func (e *EMFCounter) Inc(labels map[string]string) {
+	entry := e.withDimensions(e.withProperties(NewEntry(e.namespace), labels), e.dimensions...)
+	entry.AddMetric(e.name, 1)
+	lo.Must(e.writer.Write([]byte(lo.Must(entry.Build()) + "\n")))
+}
+
+func (e *EMFCounter) Add(v float64, labels map[string]string) {
+	entry := e.withProperties(NewEntry(e.namespace), labels)
+	entry.AddMetric(e.name, v)
+	lo.Must(e.writer.Write([]byte(lo.Must(entry.Build()) + "\n")))
+}
+
+func (e *EMFCounter) Delete(_ map[string]string) {}
+
+func (e *EMFCounter) DeletePartialMatch(_ map[string]string) {}
+
+func (e *EMF) Reset() {}
+
+type EMFGauge struct {
+	*EMF
+}
+
+func NewEMFGauge(writer io.Writer, namespace, name string, dimensions [][]string, additionalProperties ...map[string]string) GaugeMetric {
+	return &EMFGauge{EMF: NewEMF(writer, namespace, name, dimensions, additionalProperties...)}
+}
+
+func (e *EMFGauge) Set(v float64, labels map[string]string) {
+	entry := e.withDimensions(e.withProperties(NewEntry(e.namespace), labels), e.dimensions...)
+	entry.AddMetric(e.name, v)
+	lo.Must(e.writer.Write([]byte(lo.Must(entry.Build()) + "\n")))
+}
+
+func (e *EMFGauge) Delete(_ map[string]string) {}
+
+func (e *EMFGauge) DeletePartialMatch(_ map[string]string) {}
+
+func (e *EMFGauge) Reset() {}
+
+type EMFObservation struct {
+	*EMF
+}
+
+func NewEMFObservation(writer io.Writer, namespace, name string, dimensions [][]string, additionalProperties ...map[string]string) ObservationMetric {
+	return &EMFObservation{EMF: NewEMF(writer, namespace, name, dimensions, additionalProperties...)}
+}
+
+func (e *EMFObservation) Observe(v float64, labels map[string]string) {
+	entry := e.withDimensions(e.withProperties(NewEntry(e.namespace), labels), e.dimensions...)
+	entry.AddMetric(e.name, v)
+	lo.Must(e.writer.Write([]byte(lo.Must(entry.Build()) + "\n")))
+}
+
+func (e *EMFObservation) Delete(_ map[string]string) {
+
+}
+
+func (e *EMFObservation) DeletePartialMatch(_ map[string]string) {
+
+}
+
+func (e *EMFObservation) Reset() {
+
+}
+
+// Copied from https://github.com/aws/aws-sdk-go-v2/blob/v1.32.0/aws/middleware/private/metrics/emf/emf.go#L23
+// We needed to make edits to this code since we need to be able to represent different sets of dimensions
+
+const (
+	emfIdentifier        = "_aws"
+	timestampKey         = "Timestamp"
+	cloudWatchMetricsKey = "CloudWatchMetrics"
+	namespaceKey         = "Namespace"
+	dimensionsKey        = "Dimensions"
+	metricsKey           = "Metrics"
+)
+
+// Entry represents a log entry in the EMF format.
+type Entry struct {
+	namespace  string
+	metrics    []metric
+	dimensions [][]string
+	fields     map[string]interface{}
+}
+
+type metric struct {
+	Name string
+}
+
+// NewEntry creates a new Entry with the specified namespace and serializer.
+func NewEntry(namespace string) Entry {
+	return Entry{
+		namespace:  namespace,
+		metrics:    []metric{},
+		dimensions: [][]string{{}},
+		fields:     map[string]interface{}{},
+	}
+}
+
+// Build constructs the EMF log entry as a JSON string.
+func (e *Entry) Build() (string, error) {
+
+	entry := map[string]interface{}{}
+
+	entry[emfIdentifier] = map[string]interface{}{
+		timestampKey: time.Now().UnixNano() / 1e6,
+		cloudWatchMetricsKey: []map[string]interface{}{
+			{
+				namespaceKey:  e.namespace,
+				dimensionsKey: e.dimensions,
+				metricsKey:    e.metrics,
+			},
+		},
+	}
+
+	for k, v := range e.fields {
+		entry[k] = v
+	}
+
+	jsonEntry, err := json.Marshal(entry)
+	if err != nil {
+		return "", err
+	}
+	return string(jsonEntry), nil
+}
+
+// AddDimensions adds a CW Dimension to the EMF entry.
+func (e *Entry) AddDimensions(dimensions ...[]string) {
+	// Dimensions are a list of lists. We only support a single list.
+	e.dimensions = append(e.dimensions, dimensions...)
+}
+
+// AddMetric adds a CW Metric to the EMF entry.
+func (e *Entry) AddMetric(key string, value float64) {
+	e.metrics = append(e.metrics, metric{key})
+	e.fields[key] = value
+}
+
+// AddProperty adds a CW Property to the EMF entry.
+// Properties are not published as metrics, but they are available in logs and in CW insights.
+func (e *Entry) AddProperty(key string, value interface{}) {
+	e.fields[key] = value
+}

--- a/metrics/multi.go
+++ b/metrics/multi.go
@@ -1,0 +1,103 @@
+package metrics
+
+type MultiCounter struct {
+	counters []CounterMetric
+}
+
+func NewMultiCounter(counters ...CounterMetric) CounterMetric {
+	return &MultiCounter{counters: counters}
+}
+
+func (mc *MultiCounter) Inc(labels map[string]string) {
+	for _, c := range mc.counters {
+		c.Inc(labels)
+	}
+}
+
+func (mc *MultiCounter) Add(v float64, labels map[string]string) {
+	for _, c := range mc.counters {
+		c.Add(v, labels)
+	}
+}
+
+func (mc *MultiCounter) Delete(labels map[string]string) {
+	for _, c := range mc.counters {
+		c.Delete(labels)
+	}
+}
+
+func (mc *MultiCounter) DeletePartialMatch(labels map[string]string) {
+	for _, c := range mc.counters {
+		c.DeletePartialMatch(labels)
+	}
+}
+
+func (mc *MultiCounter) Reset() {
+	for _, c := range mc.counters {
+		c.Reset()
+	}
+}
+
+type MultiGauge struct {
+	gauges []GaugeMetric
+}
+
+func NewMultiGauge(gauges ...GaugeMetric) GaugeMetric {
+	return &MultiGauge{gauges: gauges}
+}
+
+func (mg *MultiGauge) Set(v float64, labels map[string]string) {
+	for _, g := range mg.gauges {
+		g.Set(v, labels)
+	}
+}
+
+func (mg *MultiGauge) Delete(labels map[string]string) {
+	for _, g := range mg.gauges {
+		g.Delete(labels)
+	}
+}
+
+func (mg *MultiGauge) DeletePartialMatch(labels map[string]string) {
+	for _, g := range mg.gauges {
+		g.DeletePartialMatch(labels)
+	}
+}
+
+func (mg *MultiGauge) Reset() {
+	for _, g := range mg.gauges {
+		g.Reset()
+	}
+}
+
+type MultiObservation struct {
+	observations []ObservationMetric
+}
+
+func NewMultiObservation(observations ...ObservationMetric) ObservationMetric {
+	return &MultiObservation{observations: observations}
+}
+
+func (mo *MultiObservation) Observe(v float64, labels map[string]string) {
+	for _, o := range mo.observations {
+		o.Observe(v, labels)
+	}
+}
+
+func (mo *MultiObservation) Delete(labels map[string]string) {
+	for _, o := range mo.observations {
+		o.Delete(labels)
+	}
+}
+
+func (mo *MultiObservation) DeletePartialMatch(labels map[string]string) {
+	for _, o := range mo.observations {
+		o.DeletePartialMatch(labels)
+	}
+}
+
+func (mo *MultiObservation) Reset() {
+	for _, o := range mo.observations {
+		o.Reset()
+	}
+}

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -1,0 +1,113 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type PrometheusCounter struct {
+	*prometheus.CounterVec
+}
+
+func NewPrometheusCounter(registry prometheus.Registerer, opts prometheus.CounterOpts, labelNames []string) CounterMetric {
+	c := prometheus.NewCounterVec(opts, labelNames)
+	registry.MustRegister(c)
+	return &PrometheusCounter{CounterVec: c}
+}
+
+func (pc *PrometheusCounter) Inc(labels map[string]string) {
+	pc.CounterVec.With(labels).Inc()
+}
+
+func (pc *PrometheusCounter) Add(v float64, labels map[string]string) {
+	pc.CounterVec.With(labels).Add(v)
+}
+
+func (pc *PrometheusCounter) Delete(labels map[string]string) {
+	pc.CounterVec.Delete(labels)
+}
+
+func (pc *PrometheusCounter) DeletePartialMatch(labels map[string]string) {
+	pc.CounterVec.DeletePartialMatch(labels)
+}
+
+func (pc *PrometheusCounter) Reset() {
+	pc.CounterVec.Reset()
+}
+
+type PrometheusGauge struct {
+	*prometheus.GaugeVec
+}
+
+func NewPrometheusGauge(registry prometheus.Registerer, opts prometheus.GaugeOpts, labelNames []string) GaugeMetric {
+	g := prometheus.NewGaugeVec(opts, labelNames)
+	registry.MustRegister(g)
+	return &PrometheusGauge{GaugeVec: g}
+}
+
+func (pg *PrometheusGauge) Set(v float64, labels map[string]string) {
+	pg.GaugeVec.With(labels).Set(v)
+}
+
+func (pg *PrometheusGauge) Delete(labels map[string]string) {
+	pg.GaugeVec.Delete(labels)
+}
+
+func (pg *PrometheusGauge) DeletePartialMatch(labels map[string]string) {
+	pg.GaugeVec.DeletePartialMatch(labels)
+}
+
+func (pg *PrometheusGauge) Reset() {
+	pg.GaugeVec.Reset()
+}
+
+type PrometheusHistogram struct {
+	*prometheus.HistogramVec
+}
+
+func NewPrometheusHistogram(registry prometheus.Registerer, opts prometheus.HistogramOpts, labelNames []string) ObservationMetric {
+	h := prometheus.NewHistogramVec(opts, labelNames)
+	registry.MustRegister(h)
+	return &PrometheusHistogram{HistogramVec: h}
+}
+
+func (ph *PrometheusHistogram) Observe(v float64, labels map[string]string) {
+	ph.HistogramVec.With(labels).Observe(v)
+}
+
+func (ph *PrometheusHistogram) Delete(labels map[string]string) {
+	ph.HistogramVec.Delete(labels)
+}
+
+func (ph *PrometheusHistogram) DeletePartialMatch(labels map[string]string) {
+	ph.HistogramVec.DeletePartialMatch(labels)
+}
+
+func (ph *PrometheusHistogram) Reset() {
+	ph.HistogramVec.Reset()
+}
+
+type PrometheusSummary struct {
+	*prometheus.SummaryVec
+}
+
+func NewPrometheusSummary(registry prometheus.Registerer, opts prometheus.SummaryOpts, labelNames []string) ObservationMetric {
+	s := prometheus.NewSummaryVec(opts, labelNames)
+	registry.MustRegister(s)
+	return &PrometheusSummary{SummaryVec: s}
+}
+
+func (ps *PrometheusSummary) Observe(v float64, labels map[string]string) {
+	ps.SummaryVec.With(labels).Observe(v)
+}
+
+func (ps *PrometheusSummary) Delete(labels map[string]string) {
+	ps.SummaryVec.Delete(labels)
+}
+
+func (ps *PrometheusSummary) DeletePartialMatch(labels map[string]string) {
+	ps.SummaryVec.DeletePartialMatch(labels)
+}
+
+func (ps *PrometheusSummary) Reset() {
+	ps.SummaryVec.Reset()
+}

--- a/metrics/types.go
+++ b/metrics/types.go
@@ -1,0 +1,23 @@
+package metrics
+
+type ObservationMetric interface {
+	Observe(v float64, labels map[string]string)
+	Delete(labels map[string]string)
+	DeletePartialMatch(labels map[string]string)
+	Reset()
+}
+
+type CounterMetric interface {
+	Add(v float64, labels map[string]string)
+	Inc(labels map[string]string)
+	Delete(labels map[string]string)
+	DeletePartialMatch(labels map[string]string)
+	Reset()
+}
+
+type GaugeMetric interface {
+	Set(v float64, labels map[string]string)
+	Delete(labels map[string]string)
+	DeletePartialMatch(labels map[string]string)
+	Reset()
+}

--- a/mock/atomic.go
+++ b/mock/atomic.go
@@ -1,17 +1,3 @@
-/*
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package mock
 
 import (

--- a/mock/function.go
+++ b/mock/function.go
@@ -1,17 +1,3 @@
-/*
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package mock
 
 import (


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change wraps the prometheus metric using an interface so that we can build multiple metric paths into the metrics that we publish. By default, we will route the metrics to prometheus but since the variables are exposed externally, users can modify the metric to create their own metric pipeline.

For instance

```
status.TerminationDuration = pmetrics.NewMultiObservation(
	status.TerminationDuration,
	pmetrics.NewEMFObservation(writer, "operatorpkg", "operator_termination_duration_seconds", []string{"group", "kind", "namespace"}),
)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
