### PR TITLE
fix: Drop namespace name from operatorpkg counter

### DIFF
--- a/status/controller.go
+++ b/status/controller.go
@@ -95,10 +95,8 @@ func (c *Controller[T]) reconcile(ctx context.Context, req reconcile.Request, o 
 			})
 			if deletionTS, ok := c.terminatingObjects.Load(req); ok {
 				TerminationDuration.Observe(time.Since(deletionTS.(*metav1.Time).Time).Seconds(), map[string]string{
-					MetricLabelGroup:     gvk.Group,
-					MetricLabelKind:      gvk.Kind,
-					MetricLabelNamespace: req.Namespace,
-					MetricLabelName:      req.Name,
+					MetricLabelGroup: gvk.Group,
+					MetricLabelKind:  gvk.Kind,
 				})
 			}
 			return reconcile.Result{}, nil

--- a/status/metrics.go
+++ b/status/metrics.go
@@ -61,7 +61,7 @@ var ConditionCount = pmetrics.NewPrometheusGauge(
 
 // Cardinality is limited to # objects * # conditions
 // NOTE: This metric is based on a requeue so it won't show the current status seconds with extremely high accuracy.
-// This metric is useful for aggreations. If you need a high accuracy metric, use operator_status_condition_last_transition_time_seconds
+// This metric is useful for aggregations. If you need a high accuracy metric, use operator_status_condition_last_transition_time_seconds
 var ConditionCurrentStatusSeconds = pmetrics.NewPrometheusGauge(
 	metrics.Registry,
 	prometheus.GaugeOpts{
@@ -126,7 +126,5 @@ var TerminationDuration = pmetrics.NewPrometheusHistogram(
 	[]string{
 		MetricLabelGroup,
 		MetricLabelKind,
-		MetricLabelNamespace,
-		MetricLabelName,
 	},
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We shouldn't have included namespace/name in our histogram counters since this is going to significantly increase the cardinality for our resources

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
