### PR TITLE
chore: Drop default empty dimension set

### DIFF
--- a/metrics/emf.go
+++ b/metrics/emf.go
@@ -138,7 +138,7 @@ func NewEntry(namespace string) Entry {
 	return Entry{
 		namespace:  namespace,
 		metrics:    []metric{},
-		dimensions: [][]string{{}},
+		dimensions: [][]string{},
 		fields:     map[string]interface{}{},
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Drop default empty dimension set in the EMF metric builder since we can explicitly pass the empty dimension set to the set of dimensions that we use in the builder if we truly need the empty set.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
