### PR TITLE
feat: Add Object Specific Metric for Status Condition Controller

### DIFF
--- a/status/metrics.go
+++ b/status/metrics.go
@@ -1,8 +1,11 @@
 package status
 
 import (
+	"fmt"
+
 	pmetrics "github.com/awslabs/operatorpkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
@@ -18,108 +21,132 @@ const (
 )
 
 // Cardinality is limited to # objects * # conditions * # objectives
-var ConditionDuration = pmetrics.NewPrometheusHistogram(
-	metrics.Registry,
-	prometheus.HistogramOpts{
-		Namespace: pmetrics.Namespace,
-		Subsystem: MetricSubsystem,
-		Name:      "transition_seconds",
-		Help:      "The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes",
-	},
-	[]string{
-		pmetrics.LabelGroup,
-		pmetrics.LabelKind,
-		pmetrics.LabelType,
-		MetricLabelConditionStatus,
-	},
-)
+var ConditionDuration = conditionDurationMetric("", pmetrics.LabelGroup, pmetrics.LabelKind)
+
+func conditionDurationMetric(objectName string, additionalLabels ...string) pmetrics.ObservationMetric {
+	subsystem := lo.Ternary(len(objectName) == 0, MetricSubsystem, fmt.Sprintf("%s_%s", objectName, MetricSubsystem))
+
+	return pmetrics.NewPrometheusHistogram(
+		metrics.Registry,
+		prometheus.HistogramOpts{
+			Namespace: pmetrics.Namespace,
+			Subsystem: subsystem,
+			Name:      "transition_seconds",
+			Help:      "The amount of time a condition was in a given state before transitioning. e.g. Alarm := P99(Updated=False) > 5 minutes",
+		},
+		append([]string{
+			pmetrics.LabelType,
+			MetricLabelConditionStatus,
+		}, additionalLabels...),
+	)
+}
 
 // Cardinality is limited to # objects * # conditions
-var ConditionCount = pmetrics.NewPrometheusGauge(
-	metrics.Registry,
-	prometheus.GaugeOpts{
-		Namespace: pmetrics.Namespace,
-		Subsystem: MetricSubsystem,
-		Name:      "count",
-		Help:      "The number of an condition for a given object, type and status. e.g. Alarm := Available=False > 0",
-	},
-	[]string{
-		MetricLabelNamespace,
-		MetricLabelName,
-		pmetrics.LabelGroup,
-		pmetrics.LabelKind,
-		pmetrics.LabelType,
-		MetricLabelConditionStatus,
-		pmetrics.LabelReason,
-	},
-)
+var ConditionCount = conditionCountMetric("", pmetrics.LabelGroup, pmetrics.LabelKind)
+
+func conditionCountMetric(objectName string, additionalLabels ...string) pmetrics.GaugeMetric {
+	subsystem := lo.Ternary(len(objectName) == 0, MetricSubsystem, fmt.Sprintf("%s_%s", objectName, MetricSubsystem))
+
+	return pmetrics.NewPrometheusGauge(
+		metrics.Registry,
+		prometheus.GaugeOpts{
+			Namespace: pmetrics.Namespace,
+			Subsystem: subsystem,
+			Name:      "count",
+			Help:      "The number of an condition for a given object, type and status. e.g. Alarm := Available=False > 0",
+		},
+		append([]string{
+			MetricLabelNamespace,
+			MetricLabelName,
+			pmetrics.LabelType,
+			MetricLabelConditionStatus,
+			pmetrics.LabelReason,
+		}, additionalLabels...),
+	)
+}
 
 // Cardinality is limited to # objects * # conditions
 // NOTE: This metric is based on a requeue so it won't show the current status seconds with extremely high accuracy.
 // This metric is useful for aggregations. If you need a high accuracy metric, use operator_status_condition_last_transition_time_seconds
-var ConditionCurrentStatusSeconds = pmetrics.NewPrometheusGauge(
-	metrics.Registry,
-	prometheus.GaugeOpts{
-		Namespace: pmetrics.Namespace,
-		Subsystem: MetricSubsystem,
-		Name:      "current_status_seconds",
-		Help:      "The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes",
-	},
-	[]string{
-		MetricLabelNamespace,
-		MetricLabelName,
-		pmetrics.LabelGroup,
-		pmetrics.LabelKind,
-		pmetrics.LabelType,
-		MetricLabelConditionStatus,
-		pmetrics.LabelReason,
-	},
-)
+var ConditionCurrentStatusSeconds = conditionCurrentStatusSecondsMetric("", pmetrics.LabelGroup, pmetrics.LabelKind)
+
+func conditionCurrentStatusSecondsMetric(objectName string, additionalLabels ...string) pmetrics.GaugeMetric {
+	subsystem := lo.Ternary(len(objectName) == 0, MetricSubsystem, fmt.Sprintf("%s_%s", objectName, MetricSubsystem))
+
+	return pmetrics.NewPrometheusGauge(
+		metrics.Registry,
+		prometheus.GaugeOpts{
+			Namespace: pmetrics.Namespace,
+			Subsystem: subsystem,
+			Name:      "current_status_seconds",
+			Help:      "The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes",
+		},
+		append([]string{
+			MetricLabelNamespace,
+			MetricLabelName,
+			pmetrics.LabelType,
+			MetricLabelConditionStatus,
+			pmetrics.LabelReason,
+		}, additionalLabels...),
+	)
+}
 
 // Cardinality is limited to # objects * # conditions
-var ConditionTransitionsTotal = pmetrics.NewPrometheusCounter(
-	metrics.Registry,
-	prometheus.CounterOpts{
-		Namespace: pmetrics.Namespace,
-		Subsystem: MetricSubsystem,
-		Name:      "transitions_total",
-		Help:      "The count of transitions of a given object, type and status.",
-	},
-	[]string{
-		pmetrics.LabelGroup,
-		pmetrics.LabelKind,
-		pmetrics.LabelType,
-		MetricLabelConditionStatus,
-		pmetrics.LabelReason,
-	},
-)
+var ConditionTransitionsTotal = conditionTransitionsTotalMetric("", pmetrics.LabelGroup, pmetrics.LabelKind)
 
-var TerminationCurrentTimeSeconds = pmetrics.NewPrometheusGauge(
-	metrics.Registry,
-	prometheus.GaugeOpts{
-		Namespace: pmetrics.Namespace,
-		Subsystem: TerminationSubsystem,
-		Name:      "current_time_seconds",
-		Help:      "The current amount of time in seconds that an object has been in terminating state.",
-	},
-	[]string{
-		MetricLabelNamespace,
-		MetricLabelName,
-		pmetrics.LabelGroup,
-		pmetrics.LabelKind,
-	},
-)
+func conditionTransitionsTotalMetric(objectName string, additionalLabels ...string) pmetrics.CounterMetric {
+	subsystem := lo.Ternary(len(objectName) == 0, MetricSubsystem, fmt.Sprintf("%s_%s", objectName, MetricSubsystem))
 
-var TerminationDuration = pmetrics.NewPrometheusHistogram(
-	metrics.Registry,
-	prometheus.HistogramOpts{
-		Namespace: pmetrics.Namespace,
-		Subsystem: TerminationSubsystem,
-		Name:      "duration_seconds",
-		Help:      "The amount of time taken by an object to terminate completely.",
-	},
-	[]string{
-		pmetrics.LabelGroup,
-		pmetrics.LabelKind,
-	},
-)
+	return pmetrics.NewPrometheusCounter(
+		metrics.Registry,
+		prometheus.CounterOpts{
+			Namespace: pmetrics.Namespace,
+			Subsystem: subsystem,
+			Name:      "transitions_total",
+			Help:      "The count of transitions of a given object, type and status.",
+		},
+		append([]string{
+			pmetrics.LabelType,
+			MetricLabelConditionStatus,
+			pmetrics.LabelReason,
+		}, additionalLabels...),
+	)
+
+}
+
+var TerminationCurrentTimeSeconds = terminationCurrentTimeSecondsMetric("", pmetrics.LabelGroup, pmetrics.LabelKind)
+
+func terminationCurrentTimeSecondsMetric(objectName string, additionalLabels ...string) pmetrics.GaugeMetric {
+	subsystem := lo.Ternary(len(objectName) == 0, TerminationSubsystem, fmt.Sprintf("%s_%s", objectName, TerminationSubsystem))
+
+	return pmetrics.NewPrometheusGauge(
+		metrics.Registry,
+		prometheus.GaugeOpts{
+			Namespace: pmetrics.Namespace,
+			Subsystem: subsystem,
+			Name:      "current_time_seconds",
+			Help:      "The current amount of time in seconds that an object has been in terminating state.",
+		},
+		append([]string{
+			MetricLabelNamespace,
+			MetricLabelName,
+		}, additionalLabels...),
+	)
+}
+
+var TerminationDuration = terminationDurationMetric("", pmetrics.LabelGroup, pmetrics.LabelKind)
+
+func terminationDurationMetric(objectName string, additionalLabels ...string) pmetrics.ObservationMetric {
+	subsystem := lo.Ternary(len(objectName) == 0, TerminationSubsystem, fmt.Sprintf("%s_%s", objectName, TerminationSubsystem))
+
+	return pmetrics.NewPrometheusHistogram(
+		metrics.Registry,
+		prometheus.HistogramOpts{
+			Namespace: pmetrics.Namespace,
+			Subsystem: subsystem,
+			Name:      "duration_seconds",
+			Help:      "The amount of time taken by an object to terminate completely.",
+		},
+		additionalLabels,
+	)
+}

--- a/status/unstructured_adapter.go
+++ b/status/unstructured_adapter.go
@@ -7,22 +7,34 @@ import (
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // unstructuredAdapter is an adapter for the status.Object interface. unstructuredAdapter
 // makes the assumption that status conditions are found on status.conditions path.
-type unstructuredAdapter struct {
+type unstructuredAdapter[T client.Object] struct {
 	unstructured.Unstructured
 }
 
-func NewUnstructuredAdapter(obj client.Object) *unstructuredAdapter {
+func NewUnstructuredAdapter[T client.Object](obj client.Object) *unstructuredAdapter[T] {
 	u := unstructured.Unstructured{Object: lo.Must(runtime.DefaultUnstructuredConverter.ToUnstructured(obj))}
-	u.SetGroupVersionKind(object.GVK(obj))
-	return &unstructuredAdapter{Unstructured: u}
+	ua := &unstructuredAdapter[T]{Unstructured: u}
+	ua.SetGroupVersionKind(object.GVK(obj))
+	return ua
 }
 
-func (u *unstructuredAdapter) GetConditions() []Condition {
+func (u *unstructuredAdapter[T]) GetObjectKind() schema.ObjectKind {
+	return u
+}
+func (u *unstructuredAdapter[T]) SetGroupVersionKind(gvk schema.GroupVersionKind) {
+	u.Unstructured.SetGroupVersionKind(gvk)
+}
+func (u *unstructuredAdapter[T]) GroupVersionKind() schema.GroupVersionKind {
+	return object.GVK(object.New[T]())
+}
+
+func (u *unstructuredAdapter[T]) GetConditions() []Condition {
 	conditions, _, _ := unstructured.NestedSlice(u.Object, "status", "conditions")
 	return lo.Map(conditions, func(condition interface{}, _ int) Condition {
 		var newCondition Condition
@@ -32,7 +44,7 @@ func (u *unstructuredAdapter) GetConditions() []Condition {
 		return newCondition
 	})
 }
-func (u *unstructuredAdapter) SetConditions(conditions []Condition) {
+func (u *unstructuredAdapter[T]) SetConditions(conditions []Condition) {
 	unstructured.SetNestedSlice(u.Object, lo.Map(conditions, func(condition Condition, _ int) interface{} {
 		var b map[string]interface{}
 		j, _ := json.Marshal(&condition)
@@ -41,7 +53,7 @@ func (u *unstructuredAdapter) SetConditions(conditions []Condition) {
 	}), "status", "conditions")
 }
 
-func (u *unstructuredAdapter) StatusConditions() ConditionSet {
+func (u *unstructuredAdapter[T]) StatusConditions() ConditionSet {
 	conditionTypes := lo.Map(u.GetConditions(), func(condition Condition, _ int) string {
 		return condition.Type
 	})

--- a/status/unstructured_adapter_test.go
+++ b/status/unstructured_adapter_test.go
@@ -2,6 +2,7 @@ package status_test
 
 import (
 	"github.com/awslabs/operatorpkg/status"
+	"github.com/awslabs/operatorpkg/test"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +36,7 @@ var _ = Describe("Unstructured Adapter", func() {
 			Kind:    "testKind",
 		})
 
-		conditionObj := status.NewUnstructuredAdapter(testObject)
+		conditionObj := status.NewUnstructuredAdapter[*test.CustomObject](testObject)
 		Expect(conditionObj).ToNot(BeNil())
 		Expect(conditionObj.StatusConditions().Get("TestType").Message).To(Equal("test message"))
 		Expect(conditionObj.StatusConditions().Get("TestType").Status).To(Equal(metav1.ConditionFalse))
@@ -69,7 +70,7 @@ var _ = Describe("Unstructured Adapter", func() {
 				Message: "test message",
 			},
 		}
-		conditionObj := status.NewUnstructuredAdapter(testObject)
+		conditionObj := status.NewUnstructuredAdapter[*test.CustomObject](testObject)
 		conditionObj.SetConditions(conditions)
 		c, found, err := unstructured.NestedSlice(testObject.Object, "status", "conditions")
 		Expect(err).To(BeNil())


### PR DESCRIPTION
Issue https://github.com/awslabs/operatorpkg/issues/87

*Description of changes:*

Auto-gen metric names based on the kind that is passed into the controller. The system for the metric will be `operator` and subsystem is `<object kind>_status_condition`. The labels used are the same statically defined metrics, with exception of the kind label, that was removed. These new metrics can be enabled using the controller options passed at controller creation. The new auto generated metrics will look as such:
- operator_<object kind>_status_condition_transitions_total
- operator_<object kind>_status_condition_transition_seconds
- operator_<object kind>_status_condition_current_status_seconds
- operator_<object kind>_status_condition_count
- operator_<object kind>_termination_current_time_seconds
- operator_<object kind>_termination_duration_seconds


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
