### PR TITLE
feat: Implemented leaderelection.LeaseHijacker

### DIFF
--- a/leaderelection/leasehijacker.go
+++ b/leaderelection/leasehijacker.go
@@ -1,0 +1,39 @@
+package leaderelection
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	coordinationv1client "k8s.io/client-go/kubernetes/typed/coordination/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// LeaseHijacker implements lease stealing to accelerate development workflows
+// TODO: migrate to https://kubernetes.io/docs/concepts/cluster-administration/coordinated-leader-election/ when it's past alpha.
+func LeaseHijacker(ctx context.Context, config *rest.Config, namespace string, name string) resourcelock.Interface {
+	if os.Getenv("HIJACK_LEASE") != "true" {
+		return nil // If not set, fallback to other controller-runtime lease settings
+	}
+	id := fmt.Sprintf("%s_%s", lo.Must(os.Hostname()), uuid.NewUUID())
+	log.FromContext(ctx).Info("hijacking lease", "namespace", namespace, "name", name)
+	kubeClient := coordinationv1client.NewForConfigOrDie(config)
+	lease := lo.Must(kubeClient.Leases(namespace).Get(ctx, name, metav1.GetOptions{}))
+	lease.Spec.HolderIdentity = lo.ToPtr(id)
+	lease.Spec.AcquireTime = lo.ToPtr(metav1.NowMicro())
+	lo.Must(kubeClient.Leases(namespace).Update(ctx, lease, metav1.UpdateOptions{}))
+	return lo.Must(resourcelock.New(
+		resourcelock.LeasesResourceLock,
+		namespace,
+		name,
+		corev1client.NewForConfigOrDie(config),
+		coordinationv1client.NewForConfigOrDie(config),
+		resourcelock.ResourceLockConfig{Identity: id},
+	))
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Enables support for developers to steal leases from a running controller.

```
LeaderElectionResourceLockInterface: leaderelection.LeaseHijacker(ctx, controllerruntime.GetConfigOrDie(), "kube-system", name),
```

```
rnal.go:512     error received after stop sequence was engaged      {"error": "leader election lost"}
sigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).engageStopProcedure.func1
        /home/etarn/workspaces//tmp/gomodcache/sigs.k8s.io/controller-runtime@v0.19.1/pkg/manager/internal.go:512
2024-11-14T22:44:59.137Z        INFO    leaderelection/leasehijacker.go:24  hijacking lease {"namespace": "kube-system", "name": "controller"}
2024-11-14T22:45:01.067Z        INFO    controller-runtime.metrics  server/server.go:208    Starting metrics server
2024-11-14T22:45:01.067Z        INFO    manager/server.go:83        starting server {"name": "health probe", "addr": "[::]:8081"}
2024-11-14T22:45:01.068Z        INFO    controller-runtime.metrics  server/server.go:247    Serving metrics server      {"bindAddress": ":8080", "secure": false}
2024-11-14T22:45:01.170Z        INFO    leaderelection/leaderelection.go:254        attempting to acquire leader lease kube-system/controller...
2024-11-14T22:45:01.185Z        INFO    leaderelection/leaderelection.go:268        successfully acquired lease kube-system/controller
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
