### PR TITLE
chore: Redundant labels from events controller

### DIFF
--- a/events/controller.go
+++ b/events/controller.go
@@ -54,8 +54,6 @@ func (c *Controller[T]) Reconcile(ctx context.Context, event *v1.Event) (reconci
 	// since we don't duplicate metrics on controller restart or lease handover
 	if c.startTime.Before(event.LastTimestamp.Time) {
 		c.EventCount.Inc(map[string]string{
-			pmetrics.LabelGroup:  c.gvk.Group,
-			pmetrics.LabelKind:   event.InvolvedObject.Kind,
 			pmetrics.LabelType:   event.Type,
 			pmetrics.LabelReason: event.Reason,
 		})

--- a/events/metrics.go
+++ b/events/metrics.go
@@ -16,8 +16,6 @@ func eventTotalMetric(objectName string) pmetrics.CounterMetric {
 			Help:      "The total of events of a given type for an object.",
 		},
 		[]string{
-			pmetrics.LabelGroup,
-			pmetrics.LabelKind,
 			pmetrics.LabelType,
 			pmetrics.LabelReason,
 		},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Removing kind and group labels
- These labels are redundant since the metric name is based on the object 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
