### PR TITLE
fix: Delete partial match if reason changes

### DIFF
--- a/status/controller.go
+++ b/status/controller.go
@@ -201,7 +201,7 @@ func (c *Controller[T]) reconcile(ctx context.Context, req reconcile.Request, o 
 	}
 
 	for _, observedCondition := range observedConditions.List() {
-		if currentCondition := currentConditions.Get(observedCondition.Type); currentCondition == nil || currentCondition.Status != observedCondition.Status {
+		if currentCondition := currentConditions.Get(observedCondition.Type); currentCondition == nil || currentCondition.Status != observedCondition.Status || currentCondition.Reason != observedCondition.Reason {
 			c.deletePartialMatchGaugeMetric(c.ConditionCount, ConditionCount, map[string]string{
 				MetricLabelNamespace:       req.Namespace,
 				MetricLabelName:            req.Name,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We should be deleting the current status and status count metrics when we get a change in reason. This should not change the amount of time that a status condition is in a given status, but should ensure that we don't leak metrics when the reason changes but the status doesn't

### Before Change

Note that there are some states that are left behind (like status=`Unknown`, reason=`AwaitingReconciliation`) even though the NodeClaim is currently `True` for all conditions

```
operator_nodeclaim_status_condition_current_status_seconds{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="default-v7bnf",namespace="",reason="AwaitingReconciliation",status="Unknown",type="Initialized"} 30.050751174
operator_nodeclaim_status_condition_current_status_seconds{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="default-v7bnf",namespace="",reason="AwaitingReconciliation",status="Unknown",type="Registered"} 2.648857492
operator_nodeclaim_status_condition_current_status_seconds{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="default-v7bnf",namespace="",reason="Consolidatable",status="True",type="Consolidatable"} 196.07353989
operator_nodeclaim_status_condition_current_status_seconds{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="default-v7bnf",namespace="",reason="Initialized",status="True",type="Initialized"} 196.073288594
operator_nodeclaim_status_condition_current_status_seconds{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="default-v7bnf",namespace="",reason="Launched",status="True",type="Launched"} 238.073260412
operator_nodeclaim_status_condition_current_status_seconds{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="default-v7bnf",namespace="",reason="NodeNotReady",status="Unknown",type="Initialized"} 40.051815263
operator_nodeclaim_status_condition_current_status_seconds{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="default-v7bnf",namespace="",reason="Ready",status="True",type="Ready"} 196.07355318
operator_nodeclaim_status_condition_current_status_seconds{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="default-v7bnf",namespace="",reason="Registered",status="True",type="Registered"} 205.073273819
```

### After Change

```
operator_nodeclaim_status_condition_current_status_seconds{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="default-rvb9x",namespace="",reason="Consolidatable",status="True",type="Consolidatable"} 1.968992336
operator_nodeclaim_status_condition_current_status_seconds{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="default-rvb9x",namespace="",reason="Initialized",status="True",type="Initialized"} 1.9689833860000001
operator_nodeclaim_status_condition_current_status_seconds{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="default-rvb9x",namespace="",reason="Launched",status="True",type="Launched"} 40.968961818
operator_nodeclaim_status_condition_current_status_seconds{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="default-rvb9x",namespace="",reason="Ready",status="True",type="Ready"} 1.969004223
operator_nodeclaim_status_condition_current_status_seconds{karpenter_k8s_aws_ec2nodeclass="default",karpenter_sh_nodepool="default",name="default-rvb9x",namespace="",reason="Registered",status="True",type="Registered"} 9.968973879
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
