### PR TITLE
Updating ExpectDelete to ignores already deleted objects

### DIFF
--- a/test/expectations/expectations.go
+++ b/test/expectations/expectations.go
@@ -162,8 +162,8 @@ func ExpectStatusUpdated(ctx context.Context, c client.Client, objects ...client
 func ExpectDeleted(ctx context.Context, c client.Client, objects ...client.Object) {
 	GinkgoHelper()
 	for _, o := range objects {
-		Expect(c.Delete(ctx, o)).To(Succeed())
-		Expect(c.Get(ctx, client.ObjectKeyFromObject(o), o)).To(Or(Succeed(), MatchError(ContainSubstring("not found"))))
+		Expect(client.IgnoreNotFound(c.Delete(ctx, o))).To(Succeed())
+		Expect(client.IgnoreNotFound(c.Get(ctx, client.ObjectKeyFromObject(o), o))).To(Succeed())
 	}
 }
 


### PR DESCRIPTION
*Description of changes:*
Updating ExpectDelete to ignores already deleted objects


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
