### PR TITLE
Update README.md fixing karpenter repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ We strive to maintain a relatively minimal dependency footprint, but some depend
 
 ## Maintainers
 
-Maintainers are limited to AWS employees, but we may consider external contributions and bug fixes. This project is maintained in service of a set of projects well known to the maintainers. We will not consider feature requests unless they are in direct support of these projects. For example, we are delighted to accept contributions from the community behind https://github.com/aws/karpenter-core. Before depending on this package, please speak with the maintainers.
+Maintainers are limited to AWS employees, but we may consider external contributions and bug fixes. This project is maintained in service of a set of projects well known to the maintainers. We will not consider feature requests unless they are in direct support of these projects. For example, we are delighted to accept contributions from the community behind https://github.com/kubernetes-sigs/karpenter. Before depending on this package, please speak with the maintainers.
 
 ## Versioning
 


### PR DESCRIPTION
Fix typo to the new Karpenter repo moved to CNCF.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
