### PR TITLE
chore: Avoid Event List call by using Clinet go Watcher

### DIFF
--- a/events/controller.go
+++ b/events/controller.go
@@ -8,15 +8,17 @@ import (
 
 	pmetrics "github.com/awslabs/operatorpkg/metrics"
 	"github.com/awslabs/operatorpkg/object"
+	"github.com/awslabs/operatorpkg/singleton"
+	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/clock"
 	controllerruntime "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -25,31 +27,32 @@ type Controller[T client.Object] struct {
 	startTime  time.Time
 	kubeClient client.Client
 	EventCount pmetrics.CounterMetric
+	eventWatch watch.Interface
 }
 
-func NewController[T client.Object](client client.Client, clock clock.Clock) *Controller[T] {
+func NewController[T client.Object](ctx context.Context, client client.Client, clock clock.Clock, kubernetesInterface kubernetes.Interface) *Controller[T] {
 	gvk := object.GVK(object.New[T]())
 	return &Controller[T]{
 		gvk:        gvk,
 		startTime:  clock.Now(),
 		kubeClient: client,
 		EventCount: eventTotalMetric(strings.ToLower(gvk.Kind)),
+		eventWatch: lo.Must(kubernetesInterface.CoreV1().Events("").Watch(ctx, metav1.ListOptions{})),
 	}
 }
 
-func (c *Controller[T]) Register(_ context.Context, m manager.Manager) error {
+func (c *Controller[T]) Register(ctx context.Context, m manager.Manager) error {
 	return controllerruntime.NewControllerManagedBy(m).
-		For(&v1.Event{}, builder.WithPredicates(predicate.NewTypedPredicateFuncs(func(o client.Object) bool {
-			// Only reconcile on the object kind we care about
-			event := o.(*v1.Event)
-			return event.InvolvedObject.Kind == c.gvk.Kind && event.InvolvedObject.APIVersion == c.gvk.GroupVersion().String()
-		}))).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
 		Named(fmt.Sprintf("operatorpkg.%s.events", strings.ToLower(c.gvk.Kind))).
-		Complete(reconcile.AsReconciler(m.GetClient(), c))
+		WatchesRawSource(singleton.ChannelSource[*v1.Event](ctx, c.eventWatch.ResultChan())).
+		Complete(reconcile.AsReconciler(c.kubeClient, c))
 }
 
 func (c *Controller[T]) Reconcile(ctx context.Context, event *v1.Event) (reconcile.Result, error) {
+	if event.InvolvedObject.Kind != c.gvk.Kind && event.InvolvedObject.APIVersion != c.gvk.GroupVersion().String() {
+		return reconcile.Result{}, nil
+	}
+
 	// We check if the event was created in the lifetime of this controller
 	// since we don't duplicate metrics on controller restart or lease handover
 	if c.startTime.Before(event.LastTimestamp.Time) {

--- a/events/controller.go
+++ b/events/controller.go
@@ -49,7 +49,7 @@ func (c *Controller[T]) Register(ctx context.Context, m manager.Manager) error {
 }
 
 func (c *Controller[T]) Reconcile(ctx context.Context, event *v1.Event) (reconcile.Result, error) {
-	if event.InvolvedObject.Kind != c.gvk.Kind && event.InvolvedObject.APIVersion != c.gvk.GroupVersion().String() {
+	if event.InvolvedObject.Kind != c.gvk.Kind || event.InvolvedObject.APIVersion != c.gvk.GroupVersion().String() {
 		return reconcile.Result{}, nil
 	}
 

--- a/singleton/controller.go
+++ b/singleton/controller.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"time"
 
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -33,6 +35,36 @@ func Source() source.Source {
 	return source.Channel(eventSource, handler.Funcs{
 		GenericFunc: func(_ context.Context, _ event.GenericEvent, queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			queue.Add(reconcile.Request{})
+		},
+	})
+}
+
+func ChannelSource[T client.Object](ctx context.Context, objectChan <-chan watch.Event) source.Source {
+	eventSource := make(chan event.GenericEvent, 1)
+
+	go func(ctx context.Context, objectChan <-chan watch.Event, eventSource chan event.GenericEvent) {
+
+		for {
+			select {
+			case delta, ok := <-objectChan:
+				if !ok {
+					return
+				}
+				// Convert the delta to GenericEvent
+				eventSource <- event.GenericEvent{
+					Object: delta.Object.(T),
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}(ctx, objectChan, eventSource)
+
+	return source.Channel(eventSource, handler.Funcs{
+		GenericFunc: func(_ context.Context, event event.GenericEvent, queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			queue.Add(reconcile.Request{
+				NamespacedName: client.ObjectKeyFromObject(event.Object),
+			})
 		},
 	})
 }


### PR DESCRIPTION
*Issue N/A

*Description of changes:*
- For cluster with large event volume size, we during controller-runtime cache hydration the initial list call made to the APIServer has heavy load on the API Server. Since we don't care about events before controller startup,  we will remove the list call done by controller-runtime and setting watcher directly on event objects.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
