### PR TITLE
feat: add expectations for reconciler requeue

### DIFF
--- a/test/expectations/expectations.go
+++ b/test/expectations/expectations.go
@@ -67,6 +67,16 @@ func ExpectReconciled(ctx context.Context, reconciler reconcile.Reconciler, obje
 	return result
 }
 
+func ExpectRequeued(result reconcile.Result) {
+	GinkgoHelper()
+	Expect(result.Requeue || result.RequeueAfter != lo.Empty[time.Duration]())
+}
+
+func ExpectNotRequeued(result reconcile.Result) {
+	GinkgoHelper()
+	Expect(!result.Requeue && result.RequeueAfter == lo.Empty[time.Duration]())
+}
+
 func ExpectObject[T client.Object](ctx context.Context, c client.Client, obj T) types.Assertion {
 	GinkgoHelper()
 	Expect(c.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds two expectations for checking if a reconciler has requeued based on a provided `reconcile.Result`. A motivating example can be found in this PR: https://github.com/kubernetes-sigs/karpenter/pull/1876.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
