### PR TITLE
fix: Fix a leak associated with not deleting from observedConditions

### DIFF
--- a/status/controller.go
+++ b/status/controller.go
@@ -134,6 +134,7 @@ func toPrometheusLabel(k string) string {
 func (c *Controller[T]) reconcile(ctx context.Context, req reconcile.Request, o Object) (reconcile.Result, error) {
 	if err := c.kubeClient.Get(ctx, req.NamespacedName, o); err != nil {
 		if errors.IsNotFound(err) {
+			c.observedConditions.Delete(req)
 			c.deletePartialMatchGaugeMetric(c.ConditionCount, ConditionCount, map[string]string{
 				MetricLabelNamespace: req.Namespace,
 				MetricLabelName:      req.Name,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We weren't deleting from `observedConditions` when the object gets deleted. This meant that we would maintain this key in the map forever.

`make presubmit`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
