### PR TITLE
Bump all obersved generation version of all conditions when object is deleting

### DIFF
--- a/status/condition_set.go
+++ b/status/condition_set.go
@@ -113,6 +113,10 @@ func (c ConditionSet) Set(condition Condition) (modified bool) {
 	condition.ObservedGeneration = c.object.GetGeneration()
 	for _, cond := range c.object.GetConditions() {
 		if cond.Type != condition.Type {
+			// If we are deleting, we just bump all the observed generations
+			if !c.object.GetDeletionTimestamp().IsZero() {
+				cond.ObservedGeneration = c.object.GetGeneration()
+			}
 			conditions = append(conditions, cond)
 		} else {
 			foundCondition = true


### PR DESCRIPTION
…

*Issue #, if available:*

*Description of changes:*

If a status condition is changed to true while the object is deleting, the root condition will transition to unknown as all the dependent conditions as from previous generation. We bump the generation of all the conditions so that the root condition remains the same as it was.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
