### PR TITLE
[WIP] feat: allow arbitrary labels for status conditions

### DIFF
--- a/test/object.go
+++ b/test/object.go
@@ -50,7 +50,13 @@ func RandomName() string {
 type CustomObject struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              CustomSpec   `json:"spec"`
 	Status            CustomStatus `json:"status"`
+}
+
+// +k8s:deepcopy-gen=true
+type CustomSpec struct {
+	CustomField string `json:"customField"`
 }
 
 // +k8s:deepcopy-gen=true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Enables users to specify arbitrary labels for status metrics. The motivating use case for this is to enable labels with values based on arbitrary fields on the object (as seen in the included test).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
