### PR TITLE
chore: Add the structured error package (`serrors`)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.0
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0
+	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
 	github.com/imdario/mergo v0.3.16
 	github.com/onsi/ginkgo/v2 v2.23.4
@@ -31,7 +32,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect

--- a/serrors/logger.go
+++ b/serrors/logger.go
@@ -1,0 +1,39 @@
+package serrors
+
+import "github.com/go-logr/logr"
+
+// Logger is a structured error logger that can be used as a wrapper for other logr.Loggers
+// It unwraps the values for structured errors and calls WithValues() for them
+type Logger struct {
+	name string
+	sink logr.LogSink
+}
+
+// NewLogger creates a new log logr.Logger using the serrors.Logger
+func NewLogger(logger logr.Logger) logr.Logger {
+	return logr.New(&Logger{sink: logger.GetSink()})
+}
+
+func (l *Logger) Init(ri logr.RuntimeInfo) {
+	l.sink.Init(ri)
+}
+
+func (l *Logger) Enabled(level int) bool {
+	return l.sink.Enabled(level)
+}
+
+func (l *Logger) Info(level int, msg string, keysAndValues ...interface{}) {
+	l.sink.Info(level, msg, keysAndValues...)
+}
+
+func (l *Logger) Error(err error, msg string, keysAndValues ...interface{}) {
+	l.sink.Error(err, msg, append(keysAndValues, UnwrapValues(err)...)...)
+}
+
+func (l *Logger) WithValues(keysAndValues ...interface{}) logr.LogSink {
+	return &Logger{name: l.name, sink: l.sink.WithValues(keysAndValues...)}
+}
+
+func (l *Logger) WithName(name string) logr.LogSink {
+	return &Logger{name: name, sink: l.sink.WithName(name)}
+}

--- a/serrors/serrors.go
+++ b/serrors/serrors.go
@@ -1,0 +1,54 @@
+package serrors
+
+import (
+	"errors"
+)
+
+// Error is a structured error that stores structured errors and values alongside the error
+type Error struct {
+	error
+	keysAndValues []any
+}
+
+// Unwrap returns the unwrapped error
+func (e *Error) Unwrap() error {
+	return e.error
+}
+
+// Error returns the string representation of the error
+func (e *Error) Error() string {
+	return e.error.Error()
+}
+
+// WithValues injects additional structured keys and values into the error
+func (e *Error) WithValues(keysAndValues ...any) *Error {
+	e.keysAndValues = append(e.keysAndValues, keysAndValues...)
+	return e
+}
+
+// Wrap wraps and existing error with additional structured keys and values
+func Wrap(err error, keysAndValues ...any) error {
+	if len(keysAndValues)%2 != 0 {
+		panic("keysAndValues must have an even number of elements")
+	}
+	for i := 0; i < len(keysAndValues); i += 2 {
+		if _, ok := keysAndValues[i].(string); !ok {
+			panic("keys must be strings")
+		}
+	}
+	return &Error{error: err, keysAndValues: keysAndValues}
+}
+
+// UnwrapValues returns a combined set of keys and values from every wrapped error
+func UnwrapValues(err error) (values []any) {
+	for err != nil {
+		if v, ok := err.(*Error); ok {
+			values = append(values, v.keysAndValues...)
+		}
+		err = errors.Unwrap(err)
+	}
+	if len(values) == 0 {
+		return nil
+	}
+	return values
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

### `serrors.Wrap`

This change adds the `serrors` package which allows callers to create structured errors with key/value pairs for better structured logging. Wrapping errors with `serrors.Wrap` will add values. If the error is wrapped multiple times, key/value pairs will be pulled out when the error is unwrapped during logging

```
for _, val := range req.Values {
	it, err := c.getInstanceType(val)
	if err != nil {
		return nil, serrors.Wrap(fmt.Errorf("instance type not found"), "instance-type", val)
	}
        ...
}
```

```
{"level":"ERROR","time":"2025-04-14T06:49:10.528Z","logger":"controller","caller":"cloudprovider/cloudprovider.go:81","message":"failed launching nodeclaim","commit":"8da13bb","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"default-ghcsc"},"namespace":"","name":"default-ghcsc","reconcileID":"478e0d8b-609e-4ce1-b4dd-2c2eb03eae06","instance-type":"m5.large","error":"instance type not found"}
```

### `serrors.Logger`

This change wraps a standard logger with a `serrors.Logger`. This logger unpacks the structured values when an error is fired and passes them through the structured values in the Error() call down the stack.

```
serrors.NewLogger(zapr.NewLogger(DefaultZapConfig(ctx, component).Build()))
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
