### PR TITLE
chore: Modify error handler middleware to return structured errors

### DIFF
--- a/aws/middleware/middleware.go
+++ b/aws/middleware/middleware.go
@@ -2,23 +2,41 @@ package middleware
 
 import (
 	"context"
+	"errors"
 
 	"github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/smithy-go"
 	"github.com/aws/smithy-go/middleware"
 	"github.com/awslabs/operatorpkg/serrors"
-	"github.com/samber/lo"
 )
 
-const AWSRequestIDLogKey = "aws-request-id"
+const (
+	AWSRequestIDLogKey     = "aws-request-id"
+	AWSStatusCodeLogKey    = "aws-status-code"
+	AWSServiceNameLogKey   = "aws-service-name"
+	AWSOperationNameLogKey = "aws-operation-name"
+	AWSErrorCodeLogKey     = "aws-error-code"
+)
 
-var RequestIDErrorHandler = func(stack *middleware.Stack) error {
-	return stack.Deserialize.Add(middleware.DeserializeMiddlewareFunc("RequestIDErrorHandler", func(ctx context.Context, in middleware.DeserializeInput, next middleware.DeserializeHandler) (middleware.DeserializeOutput, middleware.Metadata, error) {
+// StructuredErrorHandler injects structured keys and values into the error returned by the AWS request
+// It doesn't modify the error message so error messages will still contain the structured values
+var StructuredErrorHandler = func(stack *middleware.Stack) error {
+	return stack.Deserialize.Add(middleware.DeserializeMiddlewareFunc("StructuredErrorHandler", func(ctx context.Context, in middleware.DeserializeInput, next middleware.DeserializeHandler) (middleware.DeserializeOutput, middleware.Metadata, error) {
 		out, metadata, err := next.HandleDeserialize(ctx, in)
-		if err != nil {
-			if v, ok := lo.ErrorsAs[*http.ResponseError](err); ok {
-				err = serrors.Wrap(err, AWSRequestIDLogKey, v.ServiceRequestID())
-			}
+		if err == nil {
+			return out, metadata, nil
 		}
-		return out, metadata, err
+		values := []any{AWSServiceNameLogKey, middleware.GetServiceID(ctx), AWSOperationNameLogKey, middleware.GetOperationName(ctx)}
+		temp := err
+		for temp != nil {
+			if v, ok := temp.(*http.ResponseError); ok {
+				values = append(values, AWSRequestIDLogKey, v.RequestID, AWSStatusCodeLogKey, v.Response.StatusCode)
+			}
+			if v, ok := temp.(*smithy.GenericAPIError); ok {
+				values = append(values, AWSErrorCodeLogKey, v.Code)
+			}
+			temp = errors.Unwrap(temp)
+		}
+		return out, metadata, serrors.Wrap(err, values...)
 	}), middleware.Before)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update the middleware to handle parsing out all details from AWS API errors, not just the request ID

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
