### PR TITLE
chore: Support structured errors for multierr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/client_model v0.6.2
 	github.com/samber/lo v1.49.1
+	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/time v0.11.0
 	k8s.io/api v0.32.3
@@ -56,7 +57,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.37.0 // indirect
 	golang.org/x/oauth2 v0.24.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect

--- a/serrors/serrors.go
+++ b/serrors/serrors.go
@@ -2,12 +2,18 @@ package serrors
 
 import (
 	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/samber/lo"
+	"go.uber.org/multierr"
 )
 
 // Error is a structured error that stores structured errors and values alongside the error
 type Error struct {
 	error
-	keysAndValues []any
+	keysAndValues map[string]any
 }
 
 // Unwrap returns the unwrapped error
@@ -17,38 +23,75 @@ func (e *Error) Unwrap() error {
 
 // Error returns the string representation of the error
 func (e *Error) Error() string {
-	return e.error.Error()
+	var elems []string
+	keys := lo.Keys(e.keysAndValues)
+	sort.Strings(keys) // sort keys so we always get a consistent ordering
+	for _, k := range keys {
+		v := e.keysAndValues[k]
+		elems = append(elems, fmt.Sprintf("%s=%v", k, v))
+	}
+	return fmt.Sprintf("%s (%s)", e.error.Error(), strings.Join(elems, ", "))
 }
 
 // WithValues injects additional structured keys and values into the error
 func (e *Error) WithValues(keysAndValues ...any) *Error {
-	e.keysAndValues = append(e.keysAndValues, keysAndValues...)
+	lo.Must0(validateKeysAndValues(keysAndValues))
+	if e.keysAndValues == nil {
+		e.keysAndValues = map[string]any{}
+	}
+	for i := 0; i < len(keysAndValues); i += 2 {
+		e.keysAndValues[keysAndValues[i].(string)] = keysAndValues[i+1]
+	}
 	return e
 }
 
 // Wrap wraps and existing error with additional structured keys and values
 func Wrap(err error, keysAndValues ...any) error {
+	e := &Error{error: err}
+	return e.WithValues(keysAndValues...)
+}
+
+func validateKeysAndValues(keysAndValues []any) error {
 	if len(keysAndValues)%2 != 0 {
-		panic("keysAndValues must have an even number of elements")
+		return fmt.Errorf("keysAndValues must have an even number of elements")
 	}
 	for i := 0; i < len(keysAndValues); i += 2 {
 		if _, ok := keysAndValues[i].(string); !ok {
-			panic("keys must be strings")
+			return fmt.Errorf("keys must be strings")
 		}
 	}
-	return &Error{error: err, keysAndValues: keysAndValues}
+	return nil
 }
 
 // UnwrapValues returns a combined set of keys and values from every wrapped error
-func UnwrapValues(err error) (values []any) {
+func UnwrapValues(err error) (res []any) {
+	values := map[string][]any{}
 	for err != nil {
-		if v, ok := err.(*Error); ok {
-			values = append(values, v.keysAndValues...)
+		for _, elem := range multierr.Errors(err) {
+			if e, ok := elem.(*Error); ok {
+				for k, v := range e.keysAndValues {
+					if _, mOk := values[k]; mOk {
+						values[k] = append(values[k], v)
+					} else {
+						values[k] = []any{v}
+					}
+				}
+			}
 		}
 		err = errors.Unwrap(err)
 	}
 	if len(values) == 0 {
 		return nil
 	}
-	return values
+	keys := lo.Keys(values)
+	sort.Strings(keys) // sort keys so we always get a consistent ordering
+	for _, k := range keys {
+		v := values[k]
+		if len(v) == 1 {
+			res = append(res, k, v[0])
+		} else {
+			res = append(res, fmt.Sprintf("%ss", k), v)
+		}
+	}
+	return res
 }

--- a/serrors/suite_test.go
+++ b/serrors/suite_test.go
@@ -1,0 +1,79 @@
+package serrors_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/operatorpkg/serrors"
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/multierr"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var ctx context.Context
+var kubeClient client.Client
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Structured Errors")
+}
+
+var _ = BeforeSuite(func() {
+	ctx = log.IntoContext(context.Background(), ginkgo.GinkgoLogr)
+})
+
+var _ = Describe("Structured Errors", func() {
+	It("should parse values from a structured error", func() {
+		err := serrors.Wrap(fmt.Errorf("test"), "key1", "value1", "key2", "value2", "key3", "value3", "key4", "value4")
+		values := serrors.UnwrapValues(err)
+		Expect(values).To(HaveLen(8))
+		Expect(values).To(HaveExactElements("key1", "value1", "key2", "value2", "key3", "value3", "key4", "value4"))
+		Expect(err.Error()).To(Equal("test (key1=value1, key2=value2, key3=value3, key4=value4)"))
+	})
+	It("should handle a multierr with the same key", func() {
+		var err error
+
+		var parts []string
+		for i := range 100 {
+			err = multierr.Append(err, serrors.Wrap(fmt.Errorf("test error %d", i), "key", fmt.Sprintf("value%d", i)))
+			parts = append(parts, fmt.Sprintf("test error %d (key=value%d)", i, i))
+		}
+		values := serrors.UnwrapValues(err)
+		Expect(values).To(HaveLen(2))
+		Expect(values[0]).To(Equal("keys"))
+		Expect(values[1]).To(HaveLen(100))
+
+		Expect(err.Error()).To(Equal(strings.Join(parts, "; ")))
+	})
+	It("should handle a multierr with the same key using klog.KRef", func() {
+		var err error
+		err = multierr.Append(err, serrors.Wrap(fmt.Errorf("test error"), "TestObject", klog.KRef("elem", "test-object-1")))
+		err = multierr.Append(err, serrors.Wrap(fmt.Errorf("test error"), "TestObject", klog.KRef("elem", "test-object-2")))
+		err = multierr.Append(err, serrors.Wrap(fmt.Errorf("test error"), "TestObject", klog.KRef("elem", "test-object-3")))
+
+		values := serrors.UnwrapValues(err)
+		Expect(values).To(HaveLen(2))
+		Expect(values[0]).To(Equal("TestObjects"))
+		Expect(values[1]).To(HaveLen(3))
+
+		Expect(err.Error()).To(Equal("test error (TestObject=elem/test-object-1); test error (TestObject=elem/test-object-2); test error (TestObject=elem/test-object-3)"))
+	})
+	It("should handle a multierr that's wrapped with another structured error", func() {
+		var err error
+		for i := range 100 {
+			err = multierr.Append(err, serrors.Wrap(fmt.Errorf("test error %d", i), "key", fmt.Sprintf("value%d", i)))
+		}
+		err = serrors.Wrap(fmt.Errorf("wrapped error 1, %w", err), "wrappedKey1", "wrappedValue1")
+		err = serrors.Wrap(fmt.Errorf("wrapped error 2, %w", err), "wrappedKey2", "wrappedValue2")
+
+		values := serrors.UnwrapValues(err)
+		Expect(values).To(HaveLen(6))
+		Expect(values).To(ContainElements("keys", "wrappedKey1", "wrappedKey2"))
+	})
+})


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Support structured errors for `multierr.Append` and `multierr.Combine`. `multierr` is more challenging because multiple structured errors can be packed together. Additionally, it's lucky that errors in a multierr have the same values. As a result, `serrors.UnwrapValues()` combines elements with the same key together into a single array of values mapped to a single key. We keep the keyed values inside the call to `Error()` to ensure that the context around the key/value is retained

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
