### PR TITLE
chore: Add WithFields option to status controllers

### DIFF
--- a/test/object.go
+++ b/test/object.go
@@ -50,7 +50,14 @@ func RandomName() string {
 type CustomObject struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              CustomSpec   `json:"spec"`
 	Status            CustomStatus `json:"status"`
+}
+
+// +k8s:deepcopy-gen=true
+type CustomSpec struct {
+	Field1 string `json:"field1,omitempty"`
+	Field2 string `json:"field2,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This adds the `WithFields()` and `WithGaugeFields()` options to the status controller to allow pulling information out of the object and injecting it into the prometheus labels


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
