### PR TITLE
update unsupported chars in toPrometheusLabel

### DIFF
--- a/status/controller.go
+++ b/status/controller.go
@@ -191,7 +191,7 @@ func (c *Controller[T]) toAdditionalGaugeMetricLabels(obj Object) map[string]str
 }
 
 func toPrometheusLabel(k string) string {
-	unsupportedChars := []string{"/", "."}
+	unsupportedChars := []string{"/", ".", "-"}
 	for _, char := range unsupportedChars {
 		k = strings.ReplaceAll(k, char, "_")
 	}


### PR DESCRIPTION
*Issue #, if available:* #157

*Description of changes:*

this change adds the dash character (`-`) to the list of unsupported characters in the toPrometheusLabel function. It is being added to better conform to the prometheus guidance[0] on label names.

[0] https://prometheus.io/docs/concepts/data_model/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
