### PR TITLE
feat: add default singleton rate limiter to replace requeue

### DIFF
--- a/singleton/suite_test.go
+++ b/singleton/suite_test.go
@@ -1,0 +1,33 @@
+package singleton_test
+
+import (
+	"testing"
+
+	"github.com/awslabs/operatorpkg/singleton"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Singleton")
+}
+
+var _ = Describe("SingletonRateLimiter", func() {
+	var rateLimiter *singleton.SingletonRateLimiter
+
+	BeforeEach(func() {
+		rateLimiter = singleton.NewSingletonRateLimiter("test-controller")
+	})
+
+	It("should return increasing delays on subsequent calls", func() {
+		firstDelay := rateLimiter.Delay()
+		Expect(firstDelay).To(BeNumerically(">=", 0))
+
+		secondDelay := rateLimiter.Delay()
+		Expect(secondDelay).To(BeNumerically(">=", firstDelay))
+
+		thirdDelay := rateLimiter.Delay()
+		Expect(thirdDelay).To(BeNumerically(">=", secondDelay))
+	})
+})


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In response to https://github.com/kubernetes-sigs/controller-runtime/pull/3107, create a default rate limiter to add to singleton controllers that replicates the behavior of `requeue: true`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
