### PR TITLE
test: refactor expectations to support karpenter project

### DIFF
--- a/test/expectations/expectations.go
+++ b/test/expectations/expectations.go
@@ -226,7 +226,11 @@ func expectCleanedUp(ctx context.Context, c client.Client, force bool, objectLis
 						g.Expect(c.Patch(ctx, &item, client.MergeFrom(stored))).To(Succeed())
 					}
 					if item.GetDeletionTimestamp().IsZero() {
-						g.Expect(client.IgnoreNotFound(c.Delete(ctx, &item, client.PropagationPolicy(metav1.DeletePropagationForeground), &client.DeleteOptions{GracePeriodSeconds: lo.ToPtr(int64(0))}))).To(Succeed())
+						if force {
+							g.Expect(client.IgnoreNotFound(c.Delete(ctx, &item, &client.DeleteOptions{GracePeriodSeconds: lo.ToPtr(int64(0))}))).To(Succeed())
+						} else {
+							g.Expect(client.IgnoreNotFound(c.Delete(ctx, &item, client.PropagationPolicy(metav1.DeletePropagationForeground), &client.DeleteOptions{GracePeriodSeconds: lo.ToPtr(int64(0))}))).To(Succeed())
+						}
 					}
 				}
 				g.Expect(c.List(ctx, metaList, client.Limit(1))).To(Succeed())

--- a/test/expectations/expectations.go
+++ b/test/expectations/expectations.go
@@ -224,13 +224,9 @@ func expectCleanedUp(ctx context.Context, c client.Client, force bool, objectLis
 						stored := item.DeepCopy()
 						item.SetFinalizers([]string{})
 						g.Expect(c.Patch(ctx, &item, client.MergeFrom(stored))).To(Succeed())
-					}
-					if item.GetDeletionTimestamp().IsZero() {
-						if force {
-							g.Expect(client.IgnoreNotFound(c.Delete(ctx, &item, &client.DeleteOptions{GracePeriodSeconds: lo.ToPtr(int64(0))}))).To(Succeed())
-						} else {
-							g.Expect(client.IgnoreNotFound(c.Delete(ctx, &item, client.PropagationPolicy(metav1.DeletePropagationForeground), &client.DeleteOptions{GracePeriodSeconds: lo.ToPtr(int64(0))}))).To(Succeed())
-						}
+						g.Expect(client.IgnoreNotFound(c.Delete(ctx, &item, &client.DeleteOptions{GracePeriodSeconds: lo.ToPtr(int64(0))}))).To(Succeed())
+					} else if item.GetDeletionTimestamp().IsZero() {
+						g.Expect(client.IgnoreNotFound(c.Delete(ctx, &item, client.PropagationPolicy(metav1.DeletePropagationForeground), &client.DeleteOptions{GracePeriodSeconds: lo.ToPtr(int64(0))}))).To(Succeed())
 					}
 				}
 				g.Expect(c.List(ctx, metaList, client.Limit(1))).To(Succeed())


### PR DESCRIPTION
Related to this PR https://github.com/kubernetes-sigs/karpenter/pull/2368

*Description of changes:*
Some expectations are not ready to be used with karpenter.
