### PR TITLE
Adding degraded status condition

### DIFF
--- a/status/condition.go
+++ b/status/condition.go
@@ -26,6 +26,10 @@ const (
 	ConditionSucceeded = "Succeeded"
 )
 
+// ConditionDegraded is a custom extension to the standard Kubernetes condition statuses.
+// It represents a state where the resource is operational but in a degraded state.
+const ConditionDegraded metav1.ConditionStatus = "Degraded"
+
 // Condition aliases the upstream type and adds additional helper methods
 type Condition metav1.Condition
 
@@ -48,6 +52,13 @@ func (c *Condition) IsUnknown() bool {
 		return true
 	}
 	return c.Status == metav1.ConditionUnknown
+}
+
+func (c *Condition) IsDegraded() bool {
+	if c == nil {
+		return false
+	}
+	return c.Status == ConditionDegraded
 }
 
 func (c *Condition) GetStatus() metav1.ConditionStatus {


### PR DESCRIPTION
*Description of changes:*

Today we only support ConditionTrue, ConditionFalse and ConditionUnknown. We also require a condition that marks Condition as degraded for a user error. This PR helps us mark status conditions as degraded.

Degraded also takes precedence over False and unknown when setting the root condition.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
