### PR TITLE
fix: Revert expect applied updating the status

### DIFF
--- a/status/suite_test.go
+++ b/status/suite_test.go
@@ -28,6 +28,7 @@ var (
 
 // +k8s:deepcopy-gen=true
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 type TestGenericObject struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/test/expectations/expectations.go
+++ b/test/expectations/expectations.go
@@ -97,33 +97,21 @@ func ExpectNotFound(ctx context.Context, c client.Client, objects ...client.Obje
 
 func ExpectApplied(ctx context.Context, c client.Client, objects ...client.Object) {
 	GinkgoHelper()
-	for _, object := range objects {
-		deletionTimestampSet := !object.GetDeletionTimestamp().IsZero()
-		current := object.DeepCopyObject().(client.Object)
-		statuscopy := object.DeepCopyObject().(client.Object) // Snapshot the status, since create/update may override
+	for _, o := range objects {
+		current := o.DeepCopyObject().(client.Object)
 
 		// Create or Update
 		if err := c.Get(ctx, client.ObjectKeyFromObject(current), current); err != nil {
 			if errors.IsNotFound(err) {
-				Expect(c.Create(ctx, object)).To(Succeed())
+				Expect(c.Create(ctx, o)).To(Succeed())
 			} else {
 				Expect(err).ToNot(HaveOccurred())
 			}
 		} else {
-			object.SetResourceVersion(current.GetResourceVersion())
-			Expect(c.Update(ctx, object)).To(Succeed())
+			Expect(c.Patch(ctx, o, client.MergeFrom(current))).To(Succeed())
 		}
-		// Update status
-		statuscopy.SetResourceVersion(object.GetResourceVersion())
-		Expect(c.Status().Update(ctx, statuscopy)).To(Or(Succeed(), MatchError(Or(ContainSubstring("not found"), ContainSubstring("the server could not find the requested resource"))))) // Some objects do not have a status
-
 		// Re-get the object to grab the updated spec and status
-		Expect(c.Get(ctx, client.ObjectKeyFromObject(object), object)).To(Succeed())
-
-		// Set the deletion timestamp by adding a finalizer and deleting
-		if deletionTimestampSet {
-			ExpectDeletionTimestampSet(ctx, c, object)
-		}
+		ExpectObject(ctx, c, o)
 	}
 }
 

--- a/test/object.go
+++ b/test/object.go
@@ -47,6 +47,7 @@ func RandomName() string {
 
 // +k8s:deepcopy-gen=true
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 type CustomObject struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Revert the `ExpectApplied()` changes since the new behavior was more confusing and this change caused downstream impact to other components that were relying on this call to only update the spec and not the status

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
