### PR TITLE
test: remove isStatusSet check

### DIFF
--- a/test/expectations/expectations.go
+++ b/test/expectations/expectations.go
@@ -119,7 +119,7 @@ func ExpectApplied(ctx context.Context, c client.Client, objects ...client.Objec
 		}, "2s", "400ms").Should(Succeed())
 		Eventually(func(g Gomega) {
 			g.Expect(c.Get(ctx, client.ObjectKeyFromObject(current), current)).To(Succeed())
-			if isStatusSet(statusCopy) && !isStatusEqual(current, statusCopy) {
+			if !isStatusEqual(current, statusCopy) {
 				statusCopy.SetResourceVersion(current.GetResourceVersion())
 				g.Expect(c.Status().Update(ctx, statusCopy)).To(Or(Succeed(), MatchError(Or(ContainSubstring("not found"), ContainSubstring("the server could not find the requested resource")))))
 			}


### PR DESCRIPTION
To fix test error on this PR https://github.com/kubernetes-sigs/karpenter/pull/2368

*Description of changes:*

When calling `ExpectApplied` it creates the resource and update the status according to k8s flow, i.e: For POD resource, it enters in `Pending` state. But instead we want to keep status sent by user in test and don't override it. It can be empty, it means the status should kept empty too, so removing `isStatusSet` will let status kept empty when set by developer in test.
