### PR TITLE
feat: update Object interface to accept ForOption varargs on StatusConditions

### DIFF
--- a/status/condition.go
+++ b/status/condition.go
@@ -11,7 +11,7 @@ type Object interface {
 	client.Object
 	GetConditions() []Condition
 	SetConditions([]Condition)
-	StatusConditions() ConditionSet
+	StatusConditions(...ForOption) ConditionSet
 }
 
 // ConditionType is a upper-camel-cased condition type.

--- a/status/unstructured_adapter.go
+++ b/status/unstructured_adapter.go
@@ -83,9 +83,9 @@ func (u *UnstructuredAdapter[T]) SetConditions(conditions []Condition) {
 	}), "status", "conditions")
 }
 
-func (u *UnstructuredAdapter[T]) StatusConditions() ConditionSet {
+func (u *UnstructuredAdapter[T]) StatusConditions(opts ...ForOption) ConditionSet {
 	conditionTypes := lo.Map(u.GetConditions(), func(condition Condition, _ int) string {
 		return condition.Type
 	})
-	return NewReadyConditions(conditionTypes...).For(u)
+	return NewReadyConditions(conditionTypes...).For(u, opts...)
 }

--- a/test/object.go
+++ b/test/object.go
@@ -73,8 +73,8 @@ const (
 	ConditionTypeBaz = "Baz"
 )
 
-func (t *CustomObject) StatusConditions() status.ConditionSet {
-	return status.NewReadyConditions(ConditionTypeFoo, ConditionTypeBar).For(t)
+func (t *CustomObject) StatusConditions(opts ...status.ForOption) status.ConditionSet {
+	return status.NewReadyConditions(ConditionTypeFoo, ConditionTypeBar).For(t, opts...)
 }
 
 func (t *CustomObject) GetConditions() []status.Condition {


### PR DESCRIPTION
Closes the loop on #204. 

The Object interface's StatusConditions() method now accepts variadic ForOption args, matching the ConditionTypes.For() signature. This allows downstream consumers to pass status.WithClock(fakeClock) through StatusConditions() in tests, ensuring condition timestamps use the fake clock instead of metav1.Now() (real wall clock).

The change is backward-compatible: existing zero-arg callers compile unchanged and get the default clock.RealClock{} behavior.


Compiled with Karpenter and deployed to a test cluster, no issues


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
