### PR TITLE
fix: migrate status controller from record.EventRecorder to events.EventRecorder

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,11 @@
+Migrates the status controller from the deprecated `record.EventRecorder`
+(k8s.io/client-go/tools/record) to `events.EventRecorder`
+(k8s.io/client-go/tools/events).
+
+The old events API is deprecated in controller-runtime v0.23.0:
+- controller-runtime commit adding the new events API and deprecating the old one: https://github.com/kubernetes-sigs/controller-runtime/commit/572fad4
+- KEP-383 (New Event API GA): https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/383-new-event-api-ga
+
+This unblocks downstream consumers (e.g. karpenter) from passing
+`mgr.GetEventRecorder()` instead of the deprecated `mgr.GetEventRecorderFor()`,
+which triggers SA1019 staticcheck failures.

--- a/status/controller.go
+++ b/status/controller.go
@@ -20,6 +20,7 @@ import (
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/tools/record"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,7 +36,8 @@ type Controller[T Object] struct {
 	additionalMetricFields        map[string]string
 	additionalGaugeMetricFields   map[string]string
 	kubeClient                    client.Client
-	eventRecorder                 record.EventRecorder
+	eventRecorder                 events.EventRecorder
+	deprecatedEventRecorder       record.EventRecorder
 	observedConditions            sync.Map // map[reconcile.Request]ConditionSet
 	observedGaugeLabels           sync.Map // map[reconcile.Request]map[string]string
 	observedFinalizers            sync.Map // map[reconcile.Request]Finalizer
@@ -107,7 +109,7 @@ func WitMaxConcurrentReconciles(m int) func(*Option) {
 	}
 }
 
-func NewController[T Object](client client.Client, eventRecorder record.EventRecorder, opts ...option.Function[Option]) *Controller[T] {
+func NewController[T Object](client client.Client, eventRecorder events.EventRecorder, opts ...option.Function[Option]) *Controller[T] {
 	options := option.Resolve(opts...)
 	obj := reflect.New(reflect.TypeOf(*new(T)).Elem()).Interface().(runtime.Object)
 	obj.GetObjectKind().SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
@@ -151,6 +153,7 @@ func NewController[T Object](client client.Client, eventRecorder record.EventRec
 }
 
 func (c *Controller[T]) Register(_ context.Context, m manager.Manager) error {
+	c.deprecatedEventRecorder = m.GetEventRecorderFor(fmt.Sprintf("operatorpkg.%s.status", strings.ToLower(c.gvk.Kind))) //nolint:staticcheck // emitting v1.Events for backward compatibility
 	return controllerruntime.NewControllerManagedBy(m).
 		For(object.New[T]()).
 		WithOptions(controller.Options{MaxConcurrentReconciles: c.maxConcurrentReconciles}).
@@ -166,7 +169,7 @@ type GenericObjectController[T client.Object] struct {
 	*Controller[*UnstructuredAdapter[T]]
 }
 
-func NewGenericObjectController[T client.Object](client client.Client, eventRecorder record.EventRecorder, opts ...option.Function[Option]) *GenericObjectController[T] {
+func NewGenericObjectController[T client.Object](client client.Client, eventRecorder events.EventRecorder, opts ...option.Function[Option]) *GenericObjectController[T] {
 	return &GenericObjectController[T]{
 		Controller: NewController[*UnstructuredAdapter[T]](client, eventRecorder, opts...),
 	}
@@ -236,7 +239,7 @@ func (c *Controller[T]) reconcile(ctx context.Context, req reconcile.Request, o 
 			}
 			if finalizers, ok := c.observedFinalizers.LoadAndDelete(req); ok {
 				for _, finalizer := range finalizers.([]string) {
-					c.eventRecorder.Event(o, v1.EventTypeNormal, "Finalized", fmt.Sprintf("Finalized %s", finalizer))
+					c.emitEvent(o, v1.EventTypeNormal, "Finalized", "Finalized", "Finalized %s", finalizer)
 				}
 			}
 			return reconcile.Result{}, nil
@@ -248,7 +251,7 @@ func (c *Controller[T]) reconcile(ctx context.Context, req reconcile.Request, o 
 	observedFinalizers, _ := c.observedFinalizers.Swap(req, o.GetFinalizers())
 	if observedFinalizers != nil {
 		for _, finalizer := range lo.Without(observedFinalizers.([]string), o.GetFinalizers()...) {
-			c.eventRecorder.Event(o, v1.EventTypeNormal, "Finalized", fmt.Sprintf("Finalized %s", finalizer))
+			c.emitEvent(o, v1.EventTypeNormal, "Finalized", "Finalized", "Finalized %s", finalizer)
 		}
 	}
 
@@ -347,15 +350,25 @@ func (c *Controller[T]) reconcile(ctx context.Context, req reconcile.Request, o 
 			pmetrics.LabelType:         observedCondition.Type,
 			MetricLabelConditionStatus: string(observedCondition.Status),
 		}, c.toAdditionalMetricLabels(o))
-		c.eventRecorder.Event(o, v1.EventTypeNormal, condition.Type, fmt.Sprintf("Status condition transitioned, Type: %s, Status: %s -> %s, Reason: %s%s",
+		c.emitEvent(o, v1.EventTypeNormal, condition.Type, "StatusConditionTransitioned",
+			"Status condition transitioned, Type: %s, Status: %s -> %s, Reason: %s%s",
 			condition.Type,
 			observedCondition.Status,
 			condition.Status,
 			condition.Reason,
 			lo.Ternary(condition.Message != "", fmt.Sprintf(", Message: %s", condition.Message), ""),
-		))
+		)
 	}
 	return reconcile.Result{RequeueAfter: time.Second * 10}, nil
+}
+
+// emitEvent emits an event via both the new events API and the deprecated v1 Events API
+// for backward compatibility with downstream consumers that watch v1.Events.
+func (c *Controller[T]) emitEvent(o client.Object, eventtype, reason, action, noteFmt string, args ...interface{}) {
+	c.eventRecorder.Eventf(o, nil, eventtype, reason, action, noteFmt, args...)
+	if c.deprecatedEventRecorder != nil {
+		c.deprecatedEventRecorder.Eventf(o, eventtype, reason, noteFmt, args...)
+	}
 }
 
 func (c *Controller[T]) incCounterMetric(current pmetrics.CounterMetric, deprecated pmetrics.CounterMetric, labels, additionalLabels map[string]string) {

--- a/status/controller_test.go
+++ b/status/controller_test.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -26,7 +26,7 @@ import (
 )
 
 var ctx context.Context
-var recorder *record.FakeRecorder
+var recorder *events.FakeRecorder
 var kubeClient client.Client
 var registry = metrics.Registry
 
@@ -41,11 +41,11 @@ var _ = AfterEach(func() {
 
 var _ = Describe("Controller", func() {
 	var ctx context.Context
-	var recorder *record.FakeRecorder
+	var recorder *events.FakeRecorder
 	var controller *status.Controller[*test.CustomObject]
 	var kubeClient client.Client
 	BeforeEach(func() {
-		recorder = record.NewFakeRecorder(10)
+		recorder = events.NewFakeRecorder(10)
 		kubeClient = fake.NewClientBuilder().WithScheme(scheme.Scheme).WithStatusSubresource(&test.CustomObject{}).Build()
 		ctx = log.IntoContext(context.Background(), GinkgoLogr)
 		controller = status.NewController[*test.CustomObject](kubeClient, recorder, status.EmitDeprecatedMetrics)
@@ -807,7 +807,7 @@ var _ = Describe("Controller", func() {
 var _ = Describe("Generic Controller", func() {
 	var genericController *status.GenericObjectController[*TestGenericObject]
 	BeforeEach(func() {
-		recorder = record.NewFakeRecorder(10)
+		recorder = events.NewFakeRecorder(10)
 		kubeClient = fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
 		ctx = log.IntoContext(context.Background(), GinkgoLogr)
 		genericController = status.NewGenericObjectController[*TestGenericObject](kubeClient, recorder, status.EmitDeprecatedMetrics)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Migrates the status controller from the deprecated `record.EventRecorder`
(k8s.io/client-go/tools/record) to `events.EventRecorder`
(k8s.io/client-go/tools/events).

The old events API is deprecated upstream:
- KEP-383 (New Event API GA): https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/383-new-event-api-ga-graduation
- client-go deprecation:
- controller-runtime v0.23.1 deprecated `GetEventRecorderFor()` in favor of `GetEventRecorder()`

This unblocks downstream consumers (e.g. karpenter) from passing
`mgr.GetEventRecorder()` instead of the deprecated `mgr.GetEventRecorderFor()`,
which triggers SA1019 staticcheck failures.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
