### PR TITLE
test: assert Ready metric still emits for generic objects that define one

### DIFF
--- a/status/controller_test.go
+++ b/status/controller_test.go
@@ -1186,6 +1186,25 @@ var _ = Describe("Generic Controller", func() {
 		Expect(GetMetric("operator_testgenericobject_status_condition_count", conditionLabels(status.ConditionReady, metav1.ConditionUnknown))).To(BeNil())
 		Expect(GetMetric("operator_testgenericobject_status_condition_current_status_seconds", conditionLabels(status.ConditionReady, metav1.ConditionUnknown))).To(BeNil())
 	})
+	It("should emit a Ready condition metric for objects that define one", func() {
+		// Objects like corev1.Node carry a real, persisted Ready condition. Skipping
+		// initialization of absent conditions must not stop us from reporting a Ready
+		// that is actually present on the object.
+		testObject := test.Object(&TestGenericObject{})
+		gvk := object.GVK(testObject)
+		testObject.Status = TestGenericStatus{
+			Conditions: []metav1.Condition{
+				{Type: status.ConditionReady, Status: metav1.ConditionTrue},
+			},
+		}
+
+		ExpectApplied(ctx, kubeClient, testObject)
+		ExpectReconciled(ctx, genericController, testObject)
+
+		Expect(GetMetric("operator_status_condition_count", conditionLabelsWithGroupKind(gvk, status.ConditionReady, metav1.ConditionTrue)).GetGauge().GetValue()).To(BeEquivalentTo(1))
+		Expect(GetMetric("operator_status_condition_current_status_seconds", conditionLabelsWithGroupKind(gvk, status.ConditionReady, metav1.ConditionTrue)).GetGauge().GetValue()).ToNot(BeZero())
+		Expect(GetMetric("operator_testgenericobject_status_condition_count", conditionLabels(status.ConditionReady, metav1.ConditionTrue)).GetGauge().GetValue()).To(BeEquivalentTo(1))
+	})
 	It("should emit transition total metrics for abnormal conditions", func() {
 		testObject := test.Object(&TestGenericObject{})
 		gvk := object.GVK(testObject)


### PR DESCRIPTION
Follow-up to #212.

#212 stopped the `GenericObjectController` from fabricating a phantom `Ready=Unknown` metric for objects that don't define a `Ready` condition, and added a test for that absent-`Ready` case.

This adds the complementary case: an object that carries a **real, persisted `Ready`** condition (e.g. `corev1.Node`, whose `Ready` is set by kubelet) must **still** emit its `Ready` metric. This confirms the `WithObservedOnly` change filters only *fabricated* conditions, not ones actually present on the object — i.e. no regression to the Node/NodeClaim/NodePool Ready metrics that legitimately flow through this path.

Test-only; passes against current main.