### PR TITLE
feat(metrics):  introduce Label type for source-of-truth dimension docs 

### DIFF
--- a/metrics/labels.go
+++ b/metrics/labels.go
@@ -1,0 +1,54 @@
+package metrics
+
+// Label is the source-of-truth description of a Prometheus metric label (a
+// "dimension"). Declaring dimensions as Labels lets a metrics documentation
+// generator emit per-dimension help text and, where the set of possible values
+// is known and stable, the list of values.
+//
+// operatorpkg exports the type (and shared operator dimensions) so that both
+// operatorpkg's own metrics and downstream projects (e.g. Karpenter) can
+// describe their dimensions with a single, consistent type.
+//
+// Conventions:
+//   - Describe a metric dimension with a Label; avoid a bare string literal in
+//     the metric's label-names slice where a documented Label already exists.
+//   - Values, when set, MUST be a list of consts, never magic strings.
+//   - Before adding a new Label, check whether an existing one already describes
+//     the dimension you need and reference it instead.
+type Label struct {
+	// Name is the Prometheus label name (the dimension key), e.g. "kind".
+	Name string
+	// Help is human-readable documentation for the dimension.
+	Help string
+	// Values, when non-empty, enumerates the stable set of values the dimension
+	// can take. Every entry MUST be sourced from a const, never a magic string.
+	Values []string
+}
+
+// Shared operator metric dimensions. The label-name consts (LabelGroup, etc.)
+// remain the values used in metric label-names slices so existing declarations
+// compile unchanged; these Label vars carry the documentation keyed by the same
+// name.
+var (
+	Group = Label{
+		Name: LabelGroup,
+		Help: "The API group of the object the metric describes, e.g. `karpenter.sh`.",
+	}
+	Kind = Label{
+		Name: LabelKind,
+		Help: "The Kind of the object the metric describes, e.g. `NodeClaim`.",
+	}
+	Type = Label{
+		Name: LabelType,
+		// `type` is reused across metric families, so document the common cases
+		// rather than enumerating a fixed Values list.
+		Help: "The type dimension. For status-condition metrics it is the status " +
+			"condition type (e.g. `Ready`); for event metrics it is the Kubernetes " +
+			"event type (`Normal` or `Warning`).",
+	}
+	Reason = Label{
+		Name: LabelReason,
+		Help: "The reason dimension. For status-condition metrics it is the condition " +
+			"reason; for event metrics it is the Kubernetes event reason.",
+	}
+)

--- a/metrics/labels.go
+++ b/metrics/labels.go
@@ -21,8 +21,19 @@ type Label struct {
 	// Help is human-readable documentation for the dimension.
 	Help string
 	// Values, when non-empty, enumerates the stable set of values the dimension
-	// can take. Every entry MUST be sourced from a const, never a magic string.
-	Values []string
+	// can take, each with its own documentation. Every value's Name MUST be
+	// sourced from a const, never a magic string.
+	Values []Value
+}
+
+// Value documents one of the stable values a metric dimension (Label) can take.
+type Value struct {
+	// Name is the dimension value. It MUST be sourced from a const, never a magic
+	// string.
+	Name string
+	// Help is human-readable documentation for this value: what it means and,
+	// where useful, why the dimension takes it.
+	Help string
 }
 
 // Shared operator metric dimensions. The label-name consts (LabelGroup, etc.)

--- a/status/metrics.go
+++ b/status/metrics.go
@@ -27,6 +27,14 @@ const (
 	TerminationSubsystem = "termination"
 )
 
+// conditionStatusValues documents the stable set of values a condition status
+// dimension can take, shared by the ConditionStatus and ToConditionStatus labels.
+var conditionStatusValues = []pmetrics.Value{
+	{Name: string(metav1.ConditionTrue), Help: "The condition holds."},
+	{Name: string(metav1.ConditionFalse), Help: "The condition does not hold."},
+	{Name: string(metav1.ConditionUnknown), Help: "The condition's state has not yet been determined."},
+}
+
 // Package-local metric dimensions specific to status-condition metrics. These
 // are co-located with their name consts (rather than in the shared metrics
 // package) because they are only emitted by the status controllers. The
@@ -43,21 +51,14 @@ var (
 	}
 	ConditionStatus = pmetrics.Label{
 		Name: MetricLabelConditionStatus,
-		Help: "The status of the condition (the state being left, for transition metrics).",
-		Values: []string{
-			string(metav1.ConditionTrue),
-			string(metav1.ConditionFalse),
-			string(metav1.ConditionUnknown),
-		},
+		Help: "The status of a status condition (e.g. the `Ready` condition). For " +
+			"transition metrics this is the state being left.",
+		Values: conditionStatusValues,
 	}
 	ToConditionStatus = pmetrics.Label{
-		Name: MetricLabelToConditionStatus,
-		Help: "The status the condition transitioned to, for transition metrics.",
-		Values: []string{
-			string(metav1.ConditionTrue),
-			string(metav1.ConditionFalse),
-			string(metav1.ConditionUnknown),
-		},
+		Name:   MetricLabelToConditionStatus,
+		Help:   "The status a condition transitioned to, for transition metrics.",
+		Values: conditionStatusValues,
 	}
 )
 

--- a/status/metrics.go
+++ b/status/metrics.go
@@ -6,6 +6,7 @@ import (
 	pmetrics "github.com/awslabs/operatorpkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
@@ -24,6 +25,40 @@ const (
 const (
 	MetricSubsystem      = "status_condition"
 	TerminationSubsystem = "termination"
+)
+
+// Package-local metric dimensions specific to status-condition metrics. These
+// are co-located with their name consts (rather than in the shared metrics
+// package) because they are only emitted by the status controllers. The
+// label-name consts above remain the values used in the metric label-names
+// slices; these Label vars carry the documentation keyed by the same name.
+var (
+	Namespace = pmetrics.Label{
+		Name: MetricLabelNamespace,
+		Help: "The namespace of the object the status-condition metric describes.",
+	}
+	Name = pmetrics.Label{
+		Name: MetricLabelName,
+		Help: "The name of the object the status-condition metric describes.",
+	}
+	ConditionStatus = pmetrics.Label{
+		Name: MetricLabelConditionStatus,
+		Help: "The status of the condition (the state being left, for transition metrics).",
+		Values: []string{
+			string(metav1.ConditionTrue),
+			string(metav1.ConditionFalse),
+			string(metav1.ConditionUnknown),
+		},
+	}
+	ToConditionStatus = pmetrics.Label{
+		Name: MetricLabelToConditionStatus,
+		Help: "The status the condition transitioned to, for transition metrics.",
+		Values: []string{
+			string(metav1.ConditionTrue),
+			string(metav1.ConditionFalse),
+			string(metav1.ConditionUnknown),
+		},
+	}
 )
 
 // Cardinality is limited to # objects * # conditions * # objectives

--- a/status/metrics.go
+++ b/status/metrics.go
@@ -35,11 +35,11 @@ const (
 var (
 	Namespace = pmetrics.Label{
 		Name: MetricLabelNamespace,
-		Help: "The namespace of the object the status-condition metric describes.",
+		Help: "The namespace of the object the metric describes.",
 	}
 	Name = pmetrics.Label{
 		Name: MetricLabelName,
-		Help: "The name of the object the status-condition metric describes.",
+		Help: "The name of the object the metric describes.",
 	}
 	ConditionStatus = pmetrics.Label{
 		Name: MetricLabelConditionStatus,


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*

This lets the code be self documenting, and allows the karpenter.sh metrics reference to also have dimensions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
