### PR TITLE
feat(metrics): make metrics label-aware (carry their []Label)

### DIFF
--- a/events/metrics.go
+++ b/events/metrics.go
@@ -15,9 +15,9 @@ func eventTotalMetric(objectName string) pmetrics.CounterMetric {
 			Name:      "event_total",
 			Help:      "The total of events of a given type for an object.",
 		},
-		[]string{
-			pmetrics.LabelType,
-			pmetrics.LabelReason,
+		[]pmetrics.Label{
+			pmetrics.Type,
+			pmetrics.Reason,
 		},
 	)
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -23,7 +23,7 @@ func RegisterClientMetrics(r prometheus.Registerer) {
 			Help:    "Request latency in seconds. Broken down by verb, group, version, kind, and subresource.",
 			Buckets: prometheus.ExponentialBuckets(0.001, 1.5, 20),
 		},
-		[]string{"verb", "group", "version", "kind", "subresource"},
+		[]Label{{Name: "verb"}, {Name: "group"}, {Name: "version"}, {Name: "kind"}, {Name: "subresource"}},
 	)}
 	clientmetrics.RequestResult = &ResultAdapter{Metric: NewPrometheusCounter(
 		r,
@@ -31,7 +31,7 @@ func RegisterClientMetrics(r prometheus.Registerer) {
 			Name: "client_go_request_total",
 			Help: "Number of HTTP requests, partitioned by status code and method.",
 		},
-		[]string{"code", "method"},
+		[]Label{{Name: "code"}, {Name: "method"}},
 	)}
 }
 

--- a/metrics/multi.go
+++ b/metrics/multi.go
@@ -38,6 +38,13 @@ func (mc *MultiCounter) Reset() {
 	}
 }
 
+func (mc *MultiCounter) Labels() []Label {
+	if len(mc.counters) == 0 {
+		return nil
+	}
+	return mc.counters[0].Labels()
+}
+
 type MultiGauge struct {
 	gauges []GaugeMetric
 }
@@ -70,6 +77,13 @@ func (mg *MultiGauge) Reset() {
 	}
 }
 
+func (mg *MultiGauge) Labels() []Label {
+	if len(mg.gauges) == 0 {
+		return nil
+	}
+	return mg.gauges[0].Labels()
+}
+
 type MultiObservation struct {
 	observations []ObservationMetric
 }
@@ -100,4 +114,11 @@ func (mo *MultiObservation) Reset() {
 	for _, o := range mo.observations {
 		o.Reset()
 	}
+}
+
+func (mo *MultiObservation) Labels() []Label {
+	if len(mo.observations) == 0 {
+		return nil
+	}
+	return mo.observations[0].Labels()
 }

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -4,15 +4,27 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type PrometheusCounter struct {
-	*prometheus.CounterVec
+// labelNames returns the Prometheus label-name slice for a set of Labels.
+func labelNames(labels []Label) []string {
+	names := make([]string, len(labels))
+	for i, l := range labels {
+		names[i] = l.Name
+	}
+	return names
 }
 
-func NewPrometheusCounter(registry prometheus.Registerer, opts prometheus.CounterOpts, labelNames []string) CounterMetric {
-	c := prometheus.NewCounterVec(opts, labelNames)
-	registry.MustRegister(c)
-	return &PrometheusCounter{CounterVec: c}
+type PrometheusCounter struct {
+	*prometheus.CounterVec
+	labels []Label
 }
+
+func NewPrometheusCounter(registry prometheus.Registerer, opts prometheus.CounterOpts, labels []Label) CounterMetric {
+	c := prometheus.NewCounterVec(opts, labelNames(labels))
+	registry.MustRegister(c)
+	return &PrometheusCounter{CounterVec: c, labels: labels}
+}
+
+func (pc *PrometheusCounter) Labels() []Label { return pc.labels }
 
 func (pc *PrometheusCounter) Inc(labels map[string]string) {
 	pc.CounterVec.With(labels).Inc()
@@ -36,13 +48,16 @@ func (pc *PrometheusCounter) Reset() {
 
 type PrometheusGauge struct {
 	*prometheus.GaugeVec
+	labels []Label
 }
 
-func NewPrometheusGauge(registry prometheus.Registerer, opts prometheus.GaugeOpts, labelNames []string) GaugeMetric {
-	g := prometheus.NewGaugeVec(opts, labelNames)
+func NewPrometheusGauge(registry prometheus.Registerer, opts prometheus.GaugeOpts, labels []Label) GaugeMetric {
+	g := prometheus.NewGaugeVec(opts, labelNames(labels))
 	registry.MustRegister(g)
-	return &PrometheusGauge{GaugeVec: g}
+	return &PrometheusGauge{GaugeVec: g, labels: labels}
 }
+
+func (pg *PrometheusGauge) Labels() []Label { return pg.labels }
 
 func (pg *PrometheusGauge) Set(v float64, labels map[string]string) {
 	pg.GaugeVec.With(labels).Set(v)
@@ -62,13 +77,16 @@ func (pg *PrometheusGauge) Reset() {
 
 type PrometheusHistogram struct {
 	*prometheus.HistogramVec
+	labels []Label
 }
 
-func NewPrometheusHistogram(registry prometheus.Registerer, opts prometheus.HistogramOpts, labelNames []string) ObservationMetric {
-	h := prometheus.NewHistogramVec(opts, labelNames)
+func NewPrometheusHistogram(registry prometheus.Registerer, opts prometheus.HistogramOpts, labels []Label) ObservationMetric {
+	h := prometheus.NewHistogramVec(opts, labelNames(labels))
 	registry.MustRegister(h)
-	return &PrometheusHistogram{HistogramVec: h}
+	return &PrometheusHistogram{HistogramVec: h, labels: labels}
 }
+
+func (ph *PrometheusHistogram) Labels() []Label { return ph.labels }
 
 func (ph *PrometheusHistogram) Observe(v float64, labels map[string]string) {
 	ph.HistogramVec.With(labels).Observe(v)
@@ -88,13 +106,16 @@ func (ph *PrometheusHistogram) Reset() {
 
 type PrometheusSummary struct {
 	*prometheus.SummaryVec
+	labels []Label
 }
 
-func NewPrometheusSummary(registry prometheus.Registerer, opts prometheus.SummaryOpts, labelNames []string) ObservationMetric {
-	s := prometheus.NewSummaryVec(opts, labelNames)
+func NewPrometheusSummary(registry prometheus.Registerer, opts prometheus.SummaryOpts, labels []Label) ObservationMetric {
+	s := prometheus.NewSummaryVec(opts, labelNames(labels))
 	registry.MustRegister(s)
-	return &PrometheusSummary{SummaryVec: s}
+	return &PrometheusSummary{SummaryVec: s, labels: labels}
 }
+
+func (ps *PrometheusSummary) Labels() []Label { return ps.labels }
 
 func (ps *PrometheusSummary) Observe(v float64, labels map[string]string) {
 	ps.SummaryVec.With(labels).Observe(v)

--- a/metrics/types.go
+++ b/metrics/types.go
@@ -13,6 +13,8 @@ type ObservationMetric interface {
 	Delete(labels map[string]string)
 	DeletePartialMatch(labels map[string]string)
 	Reset()
+	// Labels returns the dimensions the metric was declared with.
+	Labels() []Label
 }
 
 type CounterMetric interface {
@@ -21,6 +23,8 @@ type CounterMetric interface {
 	Delete(labels map[string]string)
 	DeletePartialMatch(labels map[string]string)
 	Reset()
+	// Labels returns the dimensions the metric was declared with.
+	Labels() []Label
 }
 
 type GaugeMetric interface {
@@ -28,4 +32,6 @@ type GaugeMetric interface {
 	Delete(labels map[string]string)
 	DeletePartialMatch(labels map[string]string)
 	Reset()
+	// Labels returns the dimensions the metric was declared with.
+	Labels() []Label
 }

--- a/status/controller.go
+++ b/status/controller.go
@@ -125,28 +125,28 @@ func NewController[T Object](client client.Client, eventRecorder record.EventRec
 		maxConcurrentReconciles:     lo.Ternary(options.MaxConcurrentReconciles <= 0, 10, options.MaxConcurrentReconciles),
 		ConditionDuration: conditionDurationMetric(strings.ToLower(gvk.Kind), options.HistogramBuckets, lo.Map(
 			append(options.MetricLabels, lo.Keys(options.MetricFields)...),
-			func(k string, _ int) string { return toPrometheusLabel(k) })...),
+			func(k string, _ int) pmetrics.Label { return pmetrics.Label{Name: toPrometheusLabel(k)} })...),
 		ConditionCount: conditionCountMetric(strings.ToLower(gvk.Kind), lo.Map(
 			append(
 				append(lo.Keys(options.MetricFields), lo.Keys(options.GaugeMetricFields)...),
 				append(options.MetricLabels, options.GaugeMetricLabels...)...,
-			), func(k string, _ int) string { return toPrometheusLabel(k) })...),
+			), func(k string, _ int) pmetrics.Label { return pmetrics.Label{Name: toPrometheusLabel(k)} })...),
 		ConditionCurrentStatusSeconds: conditionCurrentStatusSecondsMetric(strings.ToLower(gvk.Kind), lo.Map(
 			append(
 				append(lo.Keys(options.MetricFields), lo.Keys(options.GaugeMetricFields)...),
 				append(options.MetricLabels, options.GaugeMetricLabels...)...,
-			), func(k string, _ int) string { return toPrometheusLabel(k) })...),
+			), func(k string, _ int) pmetrics.Label { return pmetrics.Label{Name: toPrometheusLabel(k)} })...),
 		ConditionTransitionsTotal: conditionTransitionsTotalMetric(strings.ToLower(gvk.Kind), lo.Map(
 			append(options.MetricLabels, lo.Keys(options.MetricFields)...),
-			func(k string, _ int) string { return toPrometheusLabel(k) })...),
+			func(k string, _ int) pmetrics.Label { return pmetrics.Label{Name: toPrometheusLabel(k)} })...),
 		TerminationCurrentTimeSeconds: terminationCurrentTimeSecondsMetric(strings.ToLower(gvk.Kind), lo.Map(
 			append(
 				append(lo.Keys(options.MetricFields), lo.Keys(options.GaugeMetricFields)...),
 				append(options.MetricLabels, options.GaugeMetricLabels...)...,
-			), func(k string, _ int) string { return toPrometheusLabel(k) })...),
+			), func(k string, _ int) pmetrics.Label { return pmetrics.Label{Name: toPrometheusLabel(k)} })...),
 		TerminationDuration: terminationDurationMetric(strings.ToLower(gvk.Kind), options.HistogramBuckets, lo.Map(
 			append(options.MetricLabels, lo.Keys(options.MetricFields)...),
-			func(k string, _ int) string { return toPrometheusLabel(k) })...),
+			func(k string, _ int) pmetrics.Label { return pmetrics.Label{Name: toPrometheusLabel(k)} })...),
 	}
 }
 

--- a/status/metrics.go
+++ b/status/metrics.go
@@ -63,9 +63,9 @@ var (
 )
 
 // Cardinality is limited to # objects * # conditions * # objectives
-var ConditionDuration = conditionDurationMetric("", nil, pmetrics.LabelGroup, pmetrics.LabelKind)
+var ConditionDuration = conditionDurationMetric("", nil, pmetrics.Group, pmetrics.Kind)
 
-func conditionDurationMetric(objectName string, buckets []float64, additionalLabels ...string) pmetrics.ObservationMetric {
+func conditionDurationMetric(objectName string, buckets []float64, additionalLabels ...pmetrics.Label) pmetrics.ObservationMetric {
 	subsystem := lo.Ternary(len(objectName) == 0, MetricSubsystem, fmt.Sprintf("%s_%s", objectName, MetricSubsystem))
 	buckets = lo.Ternary(len(buckets) == 0, prometheus.DefBuckets, buckets)
 
@@ -78,18 +78,18 @@ func conditionDurationMetric(objectName string, buckets []float64, additionalLab
 			Help:      "The amount of time a condition was in a given state (status) before transitioning to another state (to_status). e.g. Alarm := P99(Updated=False) > 5 minutes",
 			Buckets:   buckets,
 		},
-		append([]string{
-			pmetrics.LabelType,
-			MetricLabelConditionStatus,
-			MetricLabelToConditionStatus,
+		append([]pmetrics.Label{
+			pmetrics.Type,
+			ConditionStatus,
+			ToConditionStatus,
 		}, additionalLabels...),
 	)
 }
 
 // Cardinality is limited to # objects * # conditions
-var ConditionCount = conditionCountMetric("", pmetrics.LabelGroup, pmetrics.LabelKind)
+var ConditionCount = conditionCountMetric("", pmetrics.Group, pmetrics.Kind)
 
-func conditionCountMetric(objectName string, additionalLabels ...string) pmetrics.GaugeMetric {
+func conditionCountMetric(objectName string, additionalLabels ...pmetrics.Label) pmetrics.GaugeMetric {
 	subsystem := lo.Ternary(len(objectName) == 0, MetricSubsystem, fmt.Sprintf("%s_%s", objectName, MetricSubsystem))
 
 	return pmetrics.NewPrometheusGauge(
@@ -100,12 +100,12 @@ func conditionCountMetric(objectName string, additionalLabels ...string) pmetric
 			Name:      "count",
 			Help:      "The number of a condition for a given object, type and status. e.g. Alarm := Available=False > 0",
 		},
-		append([]string{
-			MetricLabelNamespace,
-			MetricLabelName,
-			pmetrics.LabelType,
-			MetricLabelConditionStatus,
-			pmetrics.LabelReason,
+		append([]pmetrics.Label{
+			Namespace,
+			Name,
+			pmetrics.Type,
+			ConditionStatus,
+			pmetrics.Reason,
 		}, additionalLabels...),
 	)
 }
@@ -113,9 +113,9 @@ func conditionCountMetric(objectName string, additionalLabels ...string) pmetric
 // Cardinality is limited to # objects * # conditions
 // NOTE: This metric is based on a requeue so it won't show the current status seconds with extremely high accuracy.
 // This metric is useful for aggregations. If you need a high accuracy metric, use operator_status_condition_last_transition_time_seconds
-var ConditionCurrentStatusSeconds = conditionCurrentStatusSecondsMetric("", pmetrics.LabelGroup, pmetrics.LabelKind)
+var ConditionCurrentStatusSeconds = conditionCurrentStatusSecondsMetric("", pmetrics.Group, pmetrics.Kind)
 
-func conditionCurrentStatusSecondsMetric(objectName string, additionalLabels ...string) pmetrics.GaugeMetric {
+func conditionCurrentStatusSecondsMetric(objectName string, additionalLabels ...pmetrics.Label) pmetrics.GaugeMetric {
 	subsystem := lo.Ternary(len(objectName) == 0, MetricSubsystem, fmt.Sprintf("%s_%s", objectName, MetricSubsystem))
 
 	return pmetrics.NewPrometheusGauge(
@@ -126,20 +126,20 @@ func conditionCurrentStatusSecondsMetric(objectName string, additionalLabels ...
 			Name:      "current_status_seconds",
 			Help:      "The current amount of time in seconds that a status condition has been in a specific state. Alarm := P99(Updated=Unknown) > 5 minutes",
 		},
-		append([]string{
-			MetricLabelNamespace,
-			MetricLabelName,
-			pmetrics.LabelType,
-			MetricLabelConditionStatus,
-			pmetrics.LabelReason,
+		append([]pmetrics.Label{
+			Namespace,
+			Name,
+			pmetrics.Type,
+			ConditionStatus,
+			pmetrics.Reason,
 		}, additionalLabels...),
 	)
 }
 
 // Cardinality is limited to # objects * # conditions
-var ConditionTransitionsTotal = conditionTransitionsTotalMetric("", pmetrics.LabelGroup, pmetrics.LabelKind)
+var ConditionTransitionsTotal = conditionTransitionsTotalMetric("", pmetrics.Group, pmetrics.Kind)
 
-func conditionTransitionsTotalMetric(objectName string, additionalLabels ...string) pmetrics.CounterMetric {
+func conditionTransitionsTotalMetric(objectName string, additionalLabels ...pmetrics.Label) pmetrics.CounterMetric {
 	subsystem := lo.Ternary(len(objectName) == 0, MetricSubsystem, fmt.Sprintf("%s_%s", objectName, MetricSubsystem))
 
 	return pmetrics.NewPrometheusCounter(
@@ -150,18 +150,18 @@ func conditionTransitionsTotalMetric(objectName string, additionalLabels ...stri
 			Name:      "transitions_total",
 			Help:      "The count of transitions of a given object, type and status.",
 		},
-		append([]string{
-			pmetrics.LabelType,
-			MetricLabelConditionStatus,
-			pmetrics.LabelReason,
+		append([]pmetrics.Label{
+			pmetrics.Type,
+			ConditionStatus,
+			pmetrics.Reason,
 		}, additionalLabels...),
 	)
 
 }
 
-var TerminationCurrentTimeSeconds = terminationCurrentTimeSecondsMetric("", pmetrics.LabelGroup, pmetrics.LabelKind)
+var TerminationCurrentTimeSeconds = terminationCurrentTimeSecondsMetric("", pmetrics.Group, pmetrics.Kind)
 
-func terminationCurrentTimeSecondsMetric(objectName string, additionalLabels ...string) pmetrics.GaugeMetric {
+func terminationCurrentTimeSecondsMetric(objectName string, additionalLabels ...pmetrics.Label) pmetrics.GaugeMetric {
 	subsystem := lo.Ternary(len(objectName) == 0, TerminationSubsystem, fmt.Sprintf("%s_%s", objectName, TerminationSubsystem))
 
 	return pmetrics.NewPrometheusGauge(
@@ -172,16 +172,16 @@ func terminationCurrentTimeSecondsMetric(objectName string, additionalLabels ...
 			Name:      "current_time_seconds",
 			Help:      "The current amount of time in seconds that an object has been in terminating state.",
 		},
-		append([]string{
-			MetricLabelNamespace,
-			MetricLabelName,
+		append([]pmetrics.Label{
+			Namespace,
+			Name,
 		}, additionalLabels...),
 	)
 }
 
-var TerminationDuration = terminationDurationMetric("", nil, pmetrics.LabelGroup, pmetrics.LabelKind)
+var TerminationDuration = terminationDurationMetric("", nil, pmetrics.Group, pmetrics.Kind)
 
-func terminationDurationMetric(objectName string, buckets []float64, additionalLabels ...string) pmetrics.ObservationMetric {
+func terminationDurationMetric(objectName string, buckets []float64, additionalLabels ...pmetrics.Label) pmetrics.ObservationMetric {
 	subsystem := lo.Ternary(len(objectName) == 0, TerminationSubsystem, fmt.Sprintf("%s_%s", objectName, TerminationSubsystem))
 	buckets = lo.Ternary(len(buckets) == 0, prometheus.DefBuckets, buckets)
 


### PR DESCRIPTION
The Prometheus* metric constructors now take []Label instead of []string, and each metric retains the Labels it was declared with (exposed via a Labels() method on the CounterMetric/GaugeMetric/ObservationMetric interfaces). The underlying Prometheus vector is still registered with the label Names.

This makes a metric the source of truth for its own dimensions — enabling downstream metrics-docs generation to read a metric's exact Labels (help + values) instead of resolving label names globally, and enabling runtime introspection/validation of the emitted label set.

BREAKING: NewPrometheus{Counter,Gauge,Histogram,Summary} signatures change from labelNames []string to labels []Label; callers pass []metrics.Label. The status/events metrics and the client-go metrics are updated accordingly.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
